### PR TITLE
Adds option to specify labels and selectors to service patches

### DIFF
--- a/lib/charms/observability_libs/v0/kubernetes_service_patch.py
+++ b/lib/charms/observability_libs/v0/kubernetes_service_patch.py
@@ -231,8 +231,8 @@ class KubernetesServicePatch(Object):
 
     def _delete_and_create_service(self, client: Client):
         service = client.get(Service, self._app, namespace=self._namespace)
-        service.metadata.name = self.service_name
-        service.metadata.resourceVersion = service.metadata.uid = None
+        service.metadata.name = self.service_name  # type: ignore[attr-defined]
+        service.metadata.resourceVersion = service.metadata.uid = None  # type: ignore[attr-defined]   # noqa: E501
         client.delete(Service, self._app, namespace=self._namespace)
         client.create(service)
 

--- a/lib/charms/observability_libs/v0/kubernetes_service_patch.py
+++ b/lib/charms/observability_libs/v0/kubernetes_service_patch.py
@@ -12,7 +12,7 @@ When modifying the default set of resources managed by Juju, one must consider t
 charm. In this case, any modifications to the default service (created during deployment), will
 be overwritten during a charm upgrade.
 
-When intialised, this library binds a handler to the parent charm's `install` and `upgrade_charm`
+When initialised, this library binds a handler to the parent charm's `install` and `upgrade_charm`
 events which applies the patch to the cluster. This should ensure that the service ports are
 correct throughout the charm's life.
 
@@ -103,7 +103,7 @@ LIBAPI = 0
 
 # Increment this PATCH version before using `charmcraft publish-lib` or reset
 # to 0 if you are raising the major API version
-LIBPATCH = 5
+LIBPATCH = 6
 
 PortDefinition = Union[Tuple[str, int], Tuple[str, int, int], Tuple[str, int, int, int]]
 ServiceType = Literal["ClusterIP", "LoadBalancer"]
@@ -118,6 +118,8 @@ class KubernetesServicePatch(Object):
         ports: Sequence[PortDefinition],
         service_name: str = None,
         service_type: ServiceType = "ClusterIP",
+        additional_labels: dict = None,
+        additional_selectors: dict = None,
     ):
         """Constructor for KubernetesServicePatch.
 
@@ -128,25 +130,34 @@ class KubernetesServicePatch(Object):
                 application name will be used.
             service_type: desired type of K8s service. Default value is in line with ServiceSpec's
                 default value.
+            additional_labels: Labels to be added to the kubernetes service (by default only
+                "app.kubernetes.io/name" is set to the service name)
+            additional_selectors: Selectors to be added to the kubernetes service (by default only
+                "app.kubernetes.io/name" is set to the service name)
         """
         super().__init__(charm, "kubernetes-service-patch")
         self.charm = charm
         self.service_name = service_name if service_name else self._app
-        self.service = self._service_object(ports, service_name, service_type)
+        self.service = self._service_object(
+            ports, service_name, service_type, additional_labels, additional_selectors
+        )
 
         # Make mypy type checking happy that self._patch is a method
         assert isinstance(self._patch, MethodType)
         # Ensure this patch is applied during the 'install' and 'upgrade-charm' events
         self.framework.observe(charm.on.install, self._patch)
         self.framework.observe(charm.on.upgrade_charm, self._patch)
+        self.framework.observe(charm.on.remove, self._on_remove)
 
     def _service_object(
         self,
         ports: Sequence[PortDefinition],
         service_name: str = None,
         service_type: ServiceType = "ClusterIP",
+        additional_labels: dict = None,
+        additional_selectors: dict = None,
     ) -> Service:
-        """Creates a valid Service representation for Alertmanager.
+        """Creates a valid Service representation.
 
         Args:
             ports: a list of tuples of the form (name, port) or (name, port, targetPort)
@@ -157,22 +168,32 @@ class KubernetesServicePatch(Object):
                 application name will be used.
             service_type: desired type of K8s service. Default value is in line with ServiceSpec's
                 default value.
+            additional_labels: Labels to be added to the kubernetes service (by default only
+                "app.kubernetes.io/name" is set to the service name)
+            additional_selectors: Selectors to be added to the kubernetes service (by default only
+                "app.kubernetes.io/name" is set to the service name)
 
         Returns:
             Service: A valid representation of a Kubernetes Service with the correct ports.
         """
         if not service_name:
             service_name = self._app
+        labels = {"app.kubernetes.io/name": service_name}
+        if additional_labels:
+            labels.update(additional_labels)
+        selector = {"app.kubernetes.io/name": service_name}
+        if additional_selectors:
+            selector.update(additional_selectors)
         return Service(
             apiVersion="v1",
             kind="Service",
             metadata=ObjectMeta(
                 namespace=self._namespace,
                 name=service_name,
-                labels={"app.kubernetes.io/name": service_name},
+                labels=labels,
             ),
             spec=ServiceSpec(
-                selector={"app.kubernetes.io/name": service_name},
+                selector=selector,
                 ports=[
                     ServicePort(
                         name=p[0],
@@ -197,7 +218,9 @@ class KubernetesServicePatch(Object):
 
         client = Client()
         try:
-            client.patch(Service, self._app, self.service, patch_type=PatchType.MERGE)
+            if self.service_name != self._app:
+                self._delete_and_create_service(client)
+            client.patch(Service, self.service_name, self.service, patch_type=PatchType.MERGE)
         except ApiError as e:
             if e.status.code == 403:
                 logger.error("Kubernetes service patch failed: `juju trust` this application.")
@@ -205,6 +228,13 @@ class KubernetesServicePatch(Object):
                 logger.error("Kubernetes service patch failed: %s", str(e))
         else:
             logger.info("Kubernetes service '%s' patched successfully", self._app)
+
+    def _delete_and_create_service(self, client: Client):
+        service = client.get(Service, self._app, namespace=self._namespace)
+        service.metadata.name = self.service_name
+        service.metadata.resourceVersion = service.metadata.uid = None
+        client.delete(Service, self._app, namespace=self._namespace)
+        client.create(service)
 
     def is_patched(self) -> bool:
         """Reports if the service patch has been applied.
@@ -220,6 +250,10 @@ class KubernetesServicePatch(Object):
         # Construct a list in the same manner, using the fetched service
         fetched_ports = [(p.port, p.targetPort) for p in service.spec.ports]  # type: ignore[attr-defined]  # noqa: E501
         return expected_ports == fetched_ports
+
+    def _on_remove(self, event):
+        client = Client()
+        client.delete(Service, self.service_name, namespace=self._namespace)
 
     @property
     def _app(self) -> str:

--- a/lib/charms/observability_libs/v0/kubernetes_service_patch.py
+++ b/lib/charms/observability_libs/v0/kubernetes_service_patch.py
@@ -120,6 +120,7 @@ class KubernetesServicePatch(Object):
         service_type: ServiceType = "ClusterIP",
         additional_labels: dict = None,
         additional_selectors: dict = None,
+        additional_annotations: dict = None,
     ):
         """Constructor for KubernetesServicePatch.
 
@@ -134,12 +135,18 @@ class KubernetesServicePatch(Object):
                 "app.kubernetes.io/name" is set to the service name)
             additional_selectors: Selectors to be added to the kubernetes service (by default only
                 "app.kubernetes.io/name" is set to the service name)
+            additional_annotations: Annotations to be added to the kubernetes service.
         """
         super().__init__(charm, "kubernetes-service-patch")
         self.charm = charm
         self.service_name = service_name if service_name else self._app
         self.service = self._service_object(
-            ports, service_name, service_type, additional_labels, additional_selectors
+            ports,
+            service_name,
+            service_type,
+            additional_labels,
+            additional_selectors,
+            additional_annotations,
         )
 
         # Make mypy type checking happy that self._patch is a method
@@ -147,7 +154,6 @@ class KubernetesServicePatch(Object):
         # Ensure this patch is applied during the 'install' and 'upgrade-charm' events
         self.framework.observe(charm.on.install, self._patch)
         self.framework.observe(charm.on.upgrade_charm, self._patch)
-        self.framework.observe(charm.on.remove, self._on_remove)
 
     def _service_object(
         self,
@@ -156,6 +162,7 @@ class KubernetesServicePatch(Object):
         service_type: ServiceType = "ClusterIP",
         additional_labels: dict = None,
         additional_selectors: dict = None,
+        additional_annotations: dict = None,
     ) -> Service:
         """Creates a valid Service representation.
 
@@ -172,16 +179,17 @@ class KubernetesServicePatch(Object):
                 "app.kubernetes.io/name" is set to the service name)
             additional_selectors: Selectors to be added to the kubernetes service (by default only
                 "app.kubernetes.io/name" is set to the service name)
+            additional_annotations: Annotations to be added to the kubernetes service.
 
         Returns:
             Service: A valid representation of a Kubernetes Service with the correct ports.
         """
         if not service_name:
             service_name = self._app
-        labels = {"app.kubernetes.io/name": service_name}
+        labels = {"app.kubernetes.io/name": self._app}
         if additional_labels:
             labels.update(additional_labels)
-        selector = {"app.kubernetes.io/name": service_name}
+        selector = {"app.kubernetes.io/name": self._app}
         if additional_selectors:
             selector.update(additional_selectors)
         return Service(
@@ -191,6 +199,7 @@ class KubernetesServicePatch(Object):
                 namespace=self._namespace,
                 name=service_name,
                 labels=labels,
+                annotations=additional_annotations,  # type: ignore[arg-type]
             ),
             spec=ServiceSpec(
                 selector=selector,
@@ -250,10 +259,6 @@ class KubernetesServicePatch(Object):
         # Construct a list in the same manner, using the fetched service
         fetched_ports = [(p.port, p.targetPort) for p in service.spec.ports]  # type: ignore[attr-defined]  # noqa: E501
         return expected_ports == fetched_ports
-
-    def _on_remove(self, event):
-        client = Client()
-        client.delete(Service, self.service_name, namespace=self._namespace)
 
     @property
     def _app(self) -> str:

--- a/tests/test_kubernetes_service.py
+++ b/tests/test_kubernetes_service.py
@@ -149,10 +149,10 @@ class TestK8sServicePatch(unittest.TestCase):
             metadata=ObjectMeta(
                 namespace="test",
                 name="custom-service-name",
-                labels={"app.kubernetes.io/name": "custom-service-name"},
+                labels={"app.kubernetes.io/name": "test-charm"},
             ),
             spec=ServiceSpec(
-                selector={"app.kubernetes.io/name": "custom-service-name"},
+                selector={"app.kubernetes.io/name": "test-charm"},
                 ports=[
                     ServicePort(name="svc1", port=1234, targetPort=1234),
                     ServicePort(name="svc2", port=1235, targetPort=1235),
@@ -253,10 +253,10 @@ class TestK8sServicePatch(unittest.TestCase):
             metadata=ObjectMeta(
                 namespace="test",
                 name="custom-lb-service-name",
-                labels={"app.kubernetes.io/name": "custom-lb-service-name"},
+                labels={"app.kubernetes.io/name": "test-charm"},
             ),
             spec=ServiceSpec(
-                selector={"app.kubernetes.io/name": "custom-lb-service-name"},
+                selector={"app.kubernetes.io/name": "test-charm"},
                 ports=[
                     ServicePort(name="test_lb_service", port=4321, targetPort=4321, nodePort=7654),
                     ServicePort(
@@ -266,7 +266,6 @@ class TestK8sServicePatch(unittest.TestCase):
                 type="LoadBalancer",
             ),
         )
-
         self.assertEqual(service_patch.service, expected_service)
 
     @patch(f"{CL_PATH}._namespace", "test")
@@ -319,12 +318,6 @@ class TestK8sServicePatch(unittest.TestCase):
         charm = self.harness.charm
         with mock.patch(f"{CL_PATH}._patch") as patch:
             charm.on.upgrade_charm.emit()
-            self.assertEqual(patch.call_count, 1)
-
-    def test_given_initialized_charm_when_remove_event_then_event_listener_is_attached(self):
-        charm = self.harness.charm
-        with mock.patch(f"{CL_PATH}._on_remove") as patch:
-            charm.on.remove.emit()
             self.assertEqual(patch.call_count, 1)
 
     @patch(f"{MOD_PATH}.Client.patch")

--- a/tests/test_kubernetes_service.py
+++ b/tests/test_kubernetes_service.py
@@ -51,6 +51,22 @@ class _TestCharmCustomServiceName(CharmBase):
         )
 
 
+class _TestCharmAdditionalLabels(CharmBase):
+    def __init__(self, *args):
+        super().__init__(*args)
+        self.additional_labels_service_patch = KubernetesServicePatch(
+            self, [("svc1", 1234, 1234), ("svc2", 1235, 1235)], additional_labels={"a": "b"}
+        )
+
+
+class _TestCharmAdditionalSelectors(CharmBase):
+    def __init__(self, *args):
+        super().__init__(*args)
+        self.additional_selectors_service_patch = KubernetesServicePatch(
+            self, [("svc1", 1234, 1234), ("svc2", 1235, 1235)], additional_selectors={"a": "b"}
+        )
+
+
 class _TestCharmLBService(CharmBase):
     def __init__(self, *args):
         super().__init__(*args)
@@ -78,6 +94,12 @@ class TestK8sServicePatch(unittest.TestCase):
         self.custom_service_name_harness = Harness(
             _TestCharmCustomServiceName, meta="name: test-charm"
         )
+        self.additional_labels_harness = Harness(
+            _TestCharmAdditionalLabels, meta="name: test-charm"
+        )
+        self.additional_selectors_harness = Harness(
+            _TestCharmAdditionalSelectors, meta="name: test-charm"
+        )
         self.lb_harness = Harness(_TestCharmLBService, meta="name: lb-test-charm")
         self.custom_lb_service_name_harness = Harness(
             _TestCharmCustomLBServiceName, meta="name: test-charm"
@@ -86,6 +108,8 @@ class TestK8sServicePatch(unittest.TestCase):
         with mock.patch(f"{CL_PATH}._namespace", "test"):
             self.harness.begin()
             self.custom_service_name_harness.begin()
+            self.additional_labels_harness.begin()
+            self.additional_selectors_harness.begin()
             self.lb_harness.begin()
             self.custom_lb_service_name_harness.begin()
 
@@ -129,6 +153,56 @@ class TestK8sServicePatch(unittest.TestCase):
             ),
             spec=ServiceSpec(
                 selector={"app.kubernetes.io/name": "custom-service-name"},
+                ports=[
+                    ServicePort(name="svc1", port=1234, targetPort=1234),
+                    ServicePort(name="svc2", port=1235, targetPort=1235),
+                ],
+                type="ClusterIP",
+            ),
+        )
+
+        self.assertEqual(service_patch.service, expected_service)
+
+    @patch(f"{CL_PATH}._namespace", "test")
+    def test_k8s_service_with_additional_labels(self):
+        service_patch = self.additional_labels_harness.charm.additional_labels_service_patch
+        self.assertEqual(service_patch.charm, self.additional_labels_harness.charm)
+
+        expected_service = Service(
+            apiVersion="v1",
+            kind="Service",
+            metadata=ObjectMeta(
+                namespace="test",
+                name="test-charm",
+                labels={"app.kubernetes.io/name": "test-charm", "a": "b"},
+            ),
+            spec=ServiceSpec(
+                selector={"app.kubernetes.io/name": "test-charm"},
+                ports=[
+                    ServicePort(name="svc1", port=1234, targetPort=1234),
+                    ServicePort(name="svc2", port=1235, targetPort=1235),
+                ],
+                type="ClusterIP",
+            ),
+        )
+
+        self.assertEqual(service_patch.service, expected_service)
+
+    @patch(f"{CL_PATH}._namespace", "test")
+    def test_k8s_service_with_additional_selectors(self):
+        service_patch = self.additional_selectors_harness.charm.additional_selectors_service_patch
+        self.assertEqual(service_patch.charm, self.additional_selectors_harness.charm)
+
+        expected_service = Service(
+            apiVersion="v1",
+            kind="Service",
+            metadata=ObjectMeta(
+                namespace="test",
+                name="test-charm",
+                labels={"app.kubernetes.io/name": "test-charm"},
+            ),
+            spec=ServiceSpec(
+                selector={"app.kubernetes.io/name": "test-charm", "a": "b"},
                 ports=[
                     ServicePort(name="svc1", port=1234, targetPort=1234),
                     ServicePort(name="svc2", port=1235, targetPort=1235),

--- a/tests/test_kubernetes_service.py
+++ b/tests/test_kubernetes_service.py
@@ -309,15 +309,23 @@ class TestK8sServicePatch(unittest.TestCase):
         )
         self.assertEqual(actual, expected)
 
-    def test_event_listener_attach(self):
+    def test_given_initialized_charm_when_install_event_then_event_listener_is_attached(self):
         charm = self.harness.charm
         with mock.patch(f"{CL_PATH}._patch") as patch:
-            # Emit the install event, patch should be called
             charm.on.install.emit()
             self.assertEqual(patch.call_count, 1)
-            # The patch should also be applied during upgrade_charm
+
+    def test_given_initialized_charm_when_upgrade_event_then_event_listener_is_attached(self):
+        charm = self.harness.charm
+        with mock.patch(f"{CL_PATH}._patch") as patch:
             charm.on.upgrade_charm.emit()
-            self.assertEqual(patch.call_count, 2)
+            self.assertEqual(patch.call_count, 1)
+
+    def test_given_initialized_charm_when_remove_event_then_event_listener_is_attached(self):
+        charm = self.harness.charm
+        with mock.patch(f"{CL_PATH}._on_remove") as patch:
+            charm.on.remove.emit()
+            self.assertEqual(patch.call_count, 1)
 
     @patch(f"{MOD_PATH}.Client.patch")
     @patch(f"{MOD_PATH}.ApiError", _FakeApiError)


### PR DESCRIPTION
- Adds option to add new labels and selector when patching a service.
- Fixes an issue where when service_names were provided, the service wasn't patched correctly