### PR TITLE
Add ability to optionally specify protocols for service ports

### DIFF
--- a/lib/charms/observability_libs/v1/kubernetes_service_patch.py
+++ b/lib/charms/observability_libs/v1/kubernetes_service_patch.py
@@ -9,16 +9,17 @@ service named after the application in the namespace (named after the Juju model
 default contains a "placeholder" port, which is 65536/TCP.
 
 When modifying the default set of resources managed by Juju, one must consider the lifecycle of the
-charm. In this case, any modifications to the default service (created during deployment), will
-be overwritten during a charm upgrade.
+charm. In this case, any modifications to the default service (created during deployment), will be
+overwritten during a charm upgrade.
 
 When initialised, this library binds a handler to the parent charm's `install` and `upgrade_charm`
 events which applies the patch to the cluster. This should ensure that the service ports are
 correct throughout the charm's life.
 
-The constructor simply takes a reference to the parent charm, and a list of Lightkube ServicePorts
-that each define a port for the service. For information regarding the Lightkube ServicePort model,
-please visit https://gtsystem.github.io/lightkube-models/1.23/models/core_v1/#serviceport.
+The constructor simply takes a reference to the parent charm, and a list of
+[`lightkube`](https://github.com/gtsystem/lightkube) ServicePorts that each define a port for the
+service. For information regarding the `lightkube` `ServicePort` model, please visit the
+`lightkube` [docs](https://gtsystem.github.io/lightkube-models/1.23/models/core_v1/#serviceport).
 
 Optionally, a name of the service (in case service name needs to be patched as well), labels,
 selectors, and annotations can be provided as keyword arguments.
@@ -39,7 +40,8 @@ EOF
 
 Then, to initialise the library:
 
-For ClusterIP services:
+For `ClusterIP` services:
+
 ```python
 # ...
 from charms.observability_libs.v0.kubernetes_service_patch import KubernetesServicePatch
@@ -53,7 +55,8 @@ class SomeCharm(CharmBase):
     # ...
 ```
 
-For LoadBalancer/NodePort services:
+For `LoadBalancer`/`NodePort` services:
+
 ```python
 # ...
 from charms.observability_libs.v0.kubernetes_service_patch import KubernetesServicePatch
@@ -69,7 +72,8 @@ class SomeCharm(CharmBase):
     # ...
 ```
 
-Port protocols can also be specified. Valid protocols are "TCP", "UDP", and "SCTP"
+Port protocols can also be specified. Valid protocols are `"TCP"`, `"UDP"`, and `"SCTP"`
+
 ```python
 # ...
 from charms.observability_libs.v0.kubernetes_service_patch import KubernetesServicePatch
@@ -117,11 +121,11 @@ logger = logging.getLogger(__name__)
 LIBID = "0042f86d0a874435adef581806cddbbb"
 
 # Increment this major API version when introducing breaking changes
-LIBAPI = 0
+LIBAPI = 1
 
 # Increment this PATCH version before using `charmcraft publish-lib` or reset
 # to 0 if you are raising the major API version
-LIBPATCH = 6
+LIBPATCH = 0
 
 ServiceType = Literal["ClusterIP", "LoadBalancer"]
 

--- a/tests/test_kubernetes_service.py
+++ b/tests/test_kubernetes_service.py
@@ -38,41 +38,51 @@ class _FakeApiError(ApiError):
 class _TestCharm(CharmBase):
     def __init__(self, *args):
         super().__init__(*args)
-        self.service_patch = KubernetesServicePatch(
-            self, [("svc1", 1234, 1234), ("svc2", 1235, 1235)]
-        )
+        svc1 = ServicePort(1234, name="svc1", targetPort=1234)
+        svc2 = ServicePort(1235, name="svc2", targetPort=1235)
+        self.service_patch = KubernetesServicePatch(self, [svc1, svc2])
 
 
 class _TestCharmCustomServiceName(CharmBase):
     def __init__(self, *args):
         super().__init__(*args)
+        svc1 = ServicePort(1234, name="svc1", targetPort=1234)
+        svc2 = ServicePort(1235, name="svc2", targetPort=1235)
         self.custom_service_name_service_patch = KubernetesServicePatch(
-            self, [("svc1", 1234, 1234), ("svc2", 1235, 1235)], service_name="custom-service-name"
+            self, [svc1, svc2], service_name="custom-service-name"
         )
 
 
 class _TestCharmAdditionalLabels(CharmBase):
     def __init__(self, *args):
         super().__init__(*args)
+        svc1 = ServicePort(1234, name="svc1", targetPort=1234)
+        svc2 = ServicePort(1235, name="svc2", targetPort=1235)
         self.additional_labels_service_patch = KubernetesServicePatch(
-            self, [("svc1", 1234, 1234), ("svc2", 1235, 1235)], additional_labels={"a": "b"}
+            self, [svc1, svc2], additional_labels={"a": "b"}
         )
 
 
 class _TestCharmAdditionalSelectors(CharmBase):
     def __init__(self, *args):
         super().__init__(*args)
+        svc1 = ServicePort(1234, name="svc1", targetPort=1234)
+        svc2 = ServicePort(1235, name="svc2", targetPort=1235)
         self.additional_selectors_service_patch = KubernetesServicePatch(
-            self, [("svc1", 1234, 1234), ("svc2", 1235, 1235)], additional_selectors={"a": "b"}
+            self, [svc1, svc2], additional_selectors={"a": "b"}
         )
 
 
 class _TestCharmLBService(CharmBase):
     def __init__(self, *args):
         super().__init__(*args)
+        test_lb_service = ServicePort(4321, name="test_lb_service", targetPort=4321, nodePort=7654)
+        test_lb_service2 = ServicePort(
+            1029, name="test_lb_service2", targetPort=1029, nodePort=3847
+        )
         self.lb_service_patch = KubernetesServicePatch(
             self,
-            [("test_lb_service", 4321, 4321, 7654), ("test_lb_service2", 1029, 1029, 3847)],
+            [test_lb_service, test_lb_service2],
             service_type="LoadBalancer",
         )
 
@@ -80,12 +90,25 @@ class _TestCharmLBService(CharmBase):
 class _TestCharmCustomLBServiceName(CharmBase):
     def __init__(self, *args):
         super().__init__(*args)
+        test_lb_service = ServicePort(4321, name="test_lb_service", targetPort=4321, nodePort=7654)
+        test_lb_service2 = ServicePort(
+            1029, name="test_lb_service2", targetPort=1029, nodePort=3847
+        )
         self.custom_lb_service_name_service_patch = KubernetesServicePatch(
             self,
-            [("test_lb_service", 4321, 4321, 7654), ("test_lb_service2", 1029, 1029, 3847)],
+            [test_lb_service, test_lb_service2],
             service_name="custom-lb-service-name",
             service_type="LoadBalancer",
         )
+
+
+class _TestCharmProtocols(CharmBase):
+    def __init__(self, *args):
+        super().__init__(*args)
+        svc1 = ServicePort(1234, name="svc1", protocol="TCP")
+        svc2 = ServicePort(1234, name="svc2", protocol="UDP")
+        svc3 = ServicePort(1234, name="svc3", protocol="SCTP")
+        self.protocols_service_patch = KubernetesServicePatch(self, [svc1, svc2, svc3])
 
 
 class TestK8sServicePatch(unittest.TestCase):
@@ -104,6 +127,7 @@ class TestK8sServicePatch(unittest.TestCase):
         self.custom_lb_service_name_harness = Harness(
             _TestCharmCustomLBServiceName, meta="name: test-charm"
         )
+        self.protocols_harness = Harness(_TestCharmProtocols, meta="name: test-charm")
         # Mock out calls to KubernetesServicePatch._namespace
         with mock.patch(f"{CL_PATH}._namespace", "test"):
             self.harness.begin()
@@ -112,6 +136,7 @@ class TestK8sServicePatch(unittest.TestCase):
             self.additional_selectors_harness.begin()
             self.lb_harness.begin()
             self.custom_lb_service_name_harness.begin()
+            self.protocols_harness.begin()
 
     @patch(f"{CL_PATH}._namespace", "test")
     def test_k8s_service(self):
@@ -272,7 +297,7 @@ class TestK8sServicePatch(unittest.TestCase):
     def test_optional_target_port_spec(self):
         service_patch = self.harness.charm.service_patch
 
-        ports = [("test-app", 8080)]
+        ports = [ServicePort(8080, name="test-app")]
         actual = service_patch._service_object(ports)
         expected = Service(
             apiVersion="v1",
@@ -284,13 +309,13 @@ class TestK8sServicePatch(unittest.TestCase):
             ),
             spec=ServiceSpec(
                 selector={"app.kubernetes.io/name": "test-charm"},
-                ports=[ServicePort(name="test-app", port=8080, targetPort=8080)],
+                ports=[ServicePort(name="test-app", port=8080)],
                 type="ClusterIP",
             ),
         )
         self.assertEqual(actual, expected)
 
-        ports = [("test-app", 8080, 9090)]
+        ports = [ServicePort(8080, name="test-app", targetPort=9090)]
         actual = service_patch._service_object(ports)
         expected = Service(
             apiVersion="v1",
@@ -307,6 +332,32 @@ class TestK8sServicePatch(unittest.TestCase):
             ),
         )
         self.assertEqual(actual, expected)
+
+    @patch(f"{CL_PATH}._namespace", "test")
+    def test_protocols(self):
+        service_patch = self.protocols_harness.charm.protocols_service_patch
+        self.assertEqual(service_patch.charm, self.protocols_harness.charm)
+
+        expected_service = Service(
+            apiVersion="v1",
+            kind="Service",
+            metadata=ObjectMeta(
+                namespace="test",
+                name="test-charm",
+                labels={"app.kubernetes.io/name": "test-charm"},
+            ),
+            spec=ServiceSpec(
+                selector={"app.kubernetes.io/name": "test-charm"},
+                ports=[
+                    ServicePort(name="svc1", port=1234, protocol="TCP"),
+                    ServicePort(name="svc2", port=1234, protocol="UDP"),
+                    ServicePort(name="svc3", port=1234, protocol="SCTP"),
+                ],
+                type="ClusterIP",
+            ),
+        )
+
+        self.assertEqual(service_patch.service, expected_service)
 
     def test_given_initialized_charm_when_install_event_then_event_listener_is_attached(self):
         charm = self.harness.charm

--- a/tests/test_kubernetes_service.py
+++ b/tests/test_kubernetes_service.py
@@ -5,7 +5,7 @@ import unittest
 from unittest import mock
 from unittest.mock import Mock, mock_open, patch
 
-from charms.observability_libs.v0.kubernetes_service_patch import KubernetesServicePatch
+from charms.observability_libs.v1.kubernetes_service_patch import KubernetesServicePatch
 from lightkube import ApiError
 from lightkube.models.core_v1 import ServicePort, ServiceSpec
 from lightkube.models.meta_v1 import ObjectMeta
@@ -14,8 +14,8 @@ from lightkube.types import PatchType
 from ops.charm import CharmBase
 from ops.testing import Harness
 
-CL_PATH = "charms.observability_libs.v0.kubernetes_service_patch.KubernetesServicePatch"
-MOD_PATH = "charms.observability_libs.v0.kubernetes_service_patch"
+CL_PATH = "charms.observability_libs.v1.kubernetes_service_patch.KubernetesServicePatch"
+MOD_PATH = "charms.observability_libs.v1.kubernetes_service_patch"
 
 
 class _FakeResponse:


### PR DESCRIPTION
Currently one is unable to create anything other than TCP service ports. This PR adds the ability to optionally specify a list of protocols (TCP, UDP, or SCTP) to go along with the list of service ports. The list of protocols are provided as a keyword argument. I would have preferred to provide the protocol as part of the tuple that gets passed in for each port, but couldn't think of a way to easily make it optional with the logic that is currently in place:
```python
ServicePort(
    name=p[0],
    port=p[1],
    targetPort=p[2] if len(p) > 2 else p[1],  # type: ignore[misc]
    nodePort=p[3] if len(p) > 3 else None,  # type: ignore[arg-type, misc]
)
for p in ports
```
If the protocol was made mandatory, then this wouldn't be an issue as the protocol could be added to the beginning of the port tuple. But since I wanted to avoid breaking the current API I opted to go the keyword argument  route. 

