### PR TITLE
Fix the docstrings in the library

### DIFF
--- a/lib/charms/observability_libs/v1/kubernetes_service_patch.py
+++ b/lib/charms/observability_libs/v1/kubernetes_service_patch.py
@@ -82,9 +82,9 @@ from lightkube.models.core_v1 import ServicePort
 class SomeCharm(CharmBase):
   def __init__(self, *args):
     # ...
-    tcp = ServicePort(443, name=f"{self.app.name}-tcp", protocol="TCP)
-    udp = ServicePort(443, name=f"{self.app.name}-udp", protocol="UDP)
-    sctp = ServicePort(443, name=f"{self.app.name}-sctp", protocol="SCTP)
+    tcp = ServicePort(443, name=f"{self.app.name}-tcp", protocol="TCP")
+    udp = ServicePort(443, name=f"{self.app.name}-udp", protocol="UDP")
+    sctp = ServicePort(443, name=f"{self.app.name}-sctp", protocol="SCTP")
     self.service_patcher = KubernetesServicePatch(self, [tcp, udp, sctp])
     # ...
 ```

--- a/lib/charms/observability_libs/v1/kubernetes_service_patch.py
+++ b/lib/charms/observability_libs/v1/kubernetes_service_patch.py
@@ -125,7 +125,7 @@ LIBAPI = 1
 
 # Increment this PATCH version before using `charmcraft publish-lib` or reset
 # to 0 if you are raising the major API version
-LIBPATCH = 0
+LIBPATCH = 1
 
 ServiceType = Literal["ClusterIP", "LoadBalancer"]
 


### PR DESCRIPTION
Some broken docstrings lead to some unfortunate syntax highlighting on Charmhub. This fixes those by adding missing quotes.