### PR TITLE
Add boilerplate for metrics_endpoint_discovery

### DIFF
--- a/lib/charms/observability_libs/v0/metrics_endpoint_discovery.py
+++ b/lib/charms/observability_libs/v0/metrics_endpoint_discovery.py
@@ -1,0 +1,32 @@
+"""TODO: Add a proper docstring here.
+
+This is a placeholder docstring for this charm library. Docstrings are
+presented on Charmhub and updated whenever you push a new version of the
+library.
+
+Complete documentation about creating and documenting libraries can be found
+in the SDK docs at https://juju.is/docs/sdk/libraries.
+
+See `charmcraft publish-lib` and `charmcraft fetch-lib` for details of how to
+share and consume charm libraries. They serve to enhance collaboration
+between charmers. Use a charmer's libraries for classes that handle
+integration with their charm.
+
+Bear in mind that new revisions of the different major API versions (v0, v1,
+v2 etc) are maintained independently.  You can continue to update v0 and v1
+after you have pushed v3.
+
+Markdown is supported, following the CommonMark specification.
+"""
+
+# The unique Charmhub library identifier, never change it
+LIBID = "a141d5620152466781ed83aafb948d03"
+
+# Increment this major API version when introducing breaking changes
+LIBAPI = 0
+
+# Increment this PATCH version before using `charmcraft publish-lib` or reset
+# to 0 if you are raising the major API version
+LIBPATCH = 1
+
+# TODO: add your code here! Happy coding!

--- a/lib/charms/observability_libs/v0/metrics_endpoint_discovery.py
+++ b/lib/charms/observability_libs/v0/metrics_endpoint_discovery.py
@@ -1,3 +1,6 @@
+# Copyright 2022 Canonical Ltd.
+# See LICENSE file for licensing details.
+
 """TODO: Add a proper docstring here.
 
 This is a placeholder docstring for this charm library. Docstrings are


### PR DESCRIPTION
Adds output from `charmcraft create-lib`.