### PR TITLE
Add Service Discovery Event

### DIFF
--- a/lib/charms/observability_libs/v0/metrics_endpoint_discovery.py
+++ b/lib/charms/observability_libs/v0/metrics_endpoint_discovery.py
@@ -1,26 +1,40 @@
 # Copyright 2022 Canonical Ltd.
 # See LICENSE file for licensing details.
 
-"""TODO: Add a proper docstring here.
+"""# MetricsEndpointDiscovery Library.
 
-This is a placeholder docstring for this charm library. Docstrings are
-presented on Charmhub and updated whenever you push a new version of the
-library.
+This library provides functionality for discovering metrics endpoints exposed
+by applications deployed to a Kubernetes cluster.
 
-Complete documentation about creating and documenting libraries can be found
-in the SDK docs at https://juju.is/docs/sdk/libraries.
+It comprises:
+- A custom event and event source for handling metrics endpoint changes.
+- Logic to observe cluster events and emit the events as appropriate.
 
-See `charmcraft publish-lib` and `charmcraft fetch-lib` for details of how to
-share and consume charm libraries. They serve to enhance collaboration
-between charmers. Use a charmer's libraries for classes that handle
-integration with their charm.
+## Using the Library
 
-Bear in mind that new revisions of the different major API versions (v0, v1,
-v2 etc) are maintained independently.  You can continue to update v0 and v1
-after you have pushed v3.
+### Handling Events
 
-Markdown is supported, following the CommonMark specification.
+To ensure that your charm can react to changing metrics endpoint events,
+use the CharmEvents extension.
+```python
+from charms.observability_libs.v0.metrics_endpoint_discovery import MetricsEndpointCharmEvents
+
+class MyCharm(CharmBase):
+
+    on = MetricsEndpointChangeCharmEvents()
+
+    def __init__(self, *args):
+        super().__init__(*args)
+
+        self.framework.observe(self.on.metrics_endpoint_change, self._on_metrics_endpoint_change)
+
+    def _on_metrics_endpoint_change(self, event):
+        self.unit.status = ActiveStatus("metrics endpoints changed")
+```
 """
+
+from ops.charm import CharmEvents
+from ops.framework import EventBase, EventSource
 
 # The unique Charmhub library identifier, never change it
 LIBID = "a141d5620152466781ed83aafb948d03"
@@ -32,4 +46,17 @@ LIBAPI = 0
 # to 0 if you are raising the major API version
 LIBPATCH = 1
 
-# TODO: add your code here! Happy coding!
+
+class MetricsEndpointChangeEvent(EventBase):
+    """A custom event for metrics endpoint changes."""
+
+    pass
+
+
+class MetricsEndpointChangeCharmEvents(CharmEvents):
+    """A CharmEvents extension for metrics endpoint changes.
+
+    Includes MetricsEndpointChangeEvent in those that can be handled.
+    """
+
+    metrics_endpoint_change = EventSource(MetricsEndpointChangeEvent)

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,0 +1,3 @@
+-r requirements.txt
+coverage
+flake8

--- a/tests/test_metrics_endpoint_discovery.py
+++ b/tests/test_metrics_endpoint_discovery.py
@@ -1,0 +1,34 @@
+# Copyright 2022 Canonical Ltd.
+# See LICENSE file for licensing details.
+
+import unittest
+
+from charms.observability_libs.v0.metrics_endpoint_discovery import (
+    MetricsEndpointChangeCharmEvents,
+)
+from ops.charm import CharmBase
+from ops.model import ActiveStatus
+from ops.testing import Harness
+
+
+class _TestCharm(CharmBase):
+    on = MetricsEndpointChangeCharmEvents()
+
+    def __init__(self, *args):
+        super().__init__(*args)
+
+        self.framework.observe(self.on.metrics_endpoint_change, self._on_metrics_endpoint_change)
+
+    def _on_metrics_endpoint_change(self, event):
+        self.unit.status = ActiveStatus("metrics endpoints changed")
+
+
+class TestMetricsEndpointDiscovery(unittest.TestCase):
+    def setUp(self) -> None:
+        self.harness = Harness(_TestCharm, meta="name: test-charm")
+
+    def test_metrics_endpoint_change_event_emitted_handled(self):
+        self.harness.begin()
+        charm = self.harness.charm
+        charm.on.metrics_endpoint_change.emit()
+        self.assertEqual(charm.unit.status, ActiveStatus("metrics endpoints changed"))

--- a/tests/test_metrics_endpoint_discovery.py
+++ b/tests/test_metrics_endpoint_discovery.py
@@ -4,7 +4,7 @@
 import unittest
 
 from charms.observability_libs.v0.metrics_endpoint_discovery import (
-    MetricsEndpointChangeCharmEvents,
+    MetricsEndpointObserver,
 )
 from ops.charm import CharmBase
 from ops.model import ActiveStatus
@@ -12,12 +12,13 @@ from ops.testing import Harness
 
 
 class _TestCharm(CharmBase):
-    on = MetricsEndpointChangeCharmEvents()
-
     def __init__(self, *args):
         super().__init__(*args)
 
-        self.framework.observe(self.on.metrics_endpoint_change, self._on_metrics_endpoint_change)
+        self.observer = MetricsEndpointObserver(self)
+        self.framework.observe(
+            self.observer.on.metrics_endpoint_change, self._on_metrics_endpoint_change
+        )
 
     def _on_metrics_endpoint_change(self, event):
         self.unit.status = ActiveStatus("metrics endpoints changed")
@@ -30,5 +31,5 @@ class TestMetricsEndpointDiscovery(unittest.TestCase):
     def test_metrics_endpoint_change_event_emitted_handled(self):
         self.harness.begin()
         charm = self.harness.charm
-        charm.on.metrics_endpoint_change.emit()
+        charm.observer.on.metrics_endpoint_change.emit()
         self.assertEqual(charm.unit.status, ActiveStatus("metrics endpoints changed"))


### PR DESCRIPTION
## Issue
We need a mechanism to dynamically discover Prometheus metrics endpoints for applications deployed to a k8s cluster.

Rather than co-opt an existing Juju hook to handle such discovery events, it is desirable to have an event dedicated to this purpose.

## Solution
Here we use the Ops facility for custom events to add a new event and event source extension, so that charms can use it to handle metrics endpoint changes.

## Context
From the charm's tools directory, such an event can be dispatched by using the `juju-run` command like this:
```bash
./juju-run -u my-application/0 "JUJU_DISPATCH_PATH=hooks/metrics_endpoint_change ./dispatch"
```

## Testing Instructions
See the usage instructions added with the new lib. Follow them to:
- Instantiate `MetricsEndpointObserver` in the initialisation logic for an existing charm.
- Add a handler for the event via the observer's `on` member.
- Deploy a unit of the charm.
- SSH to the unit.
- For the unit's tools directory, dispatch the event as described in _Context_ above.
- Verify that the handler was invoked.

## Release Notes
Adds a new custom hook event that can be recruited to handle upcoming metrics endpoint changes within a K8s cluster.
