### PR TITLE
Adds process spawning and event dispatch to MetricEndpointsObserver

### DIFF
--- a/lib/charms/observability_libs/v0/metrics_endpoint_discovery.py
+++ b/lib/charms/observability_libs/v0/metrics_endpoint_discovery.py
@@ -68,6 +68,9 @@ LIBPATCH = 1
 # between the discovery process and the materialised event.
 PAYLOAD_FILE_PATH = "/tmp/metrics-endpoint-payload.json"
 
+# File path for the spawned discovery process to write logs.
+LOG_FILE_PATH = "/var/log/discovery.log"
+
 
 class MetricsEndpointChangeEvent(EventBase):
     """A custom event for metrics endpoint changes."""
@@ -133,7 +136,8 @@ class MetricsEndpointObserver(Object):
         # We need to trick Juju into thinking that we are not running
         # in a hook context, as Juju will disallow use of juju-run.
         new_env = os.environ.copy()
-        new_env.pop("JUJU_CONTEXT_ID")
+        if "JUJU_CONTEXT_ID" in new_env:
+            new_env.pop("JUJU_CONTEXT_ID")
 
         pid = subprocess.Popen(
             [
@@ -144,7 +148,7 @@ class MetricsEndpointObserver(Object):
                 self._charm.unit.name,
                 self._charm.charm_dir,
             ],
-            stdout=open("/var/log/discovery.log", "a"),
+            stdout=open(LOG_FILE_PATH, "a"),
             stderr=subprocess.STDOUT,
             env=new_env,
         ).pid

--- a/lib/charms/observability_libs/v0/metrics_endpoint_discovery.py
+++ b/lib/charms/observability_libs/v0/metrics_endpoint_discovery.py
@@ -36,8 +36,19 @@ class MyCharm(CharmBase):
 ```
 """
 
+import json
+import logging
+import os
+import signal
+import subprocess
+import sys
+
+from lightkube import Client
+from lightkube.resources.core_v1 import Pod
 from ops.charm import CharmBase, CharmEvents
 from ops.framework import EventBase, EventSource, Object
+
+logger = logging.getLogger(__name__)
 
 # The unique Charmhub library identifier, never change it
 LIBID = "a141d5620152466781ed83aafb948d03"
@@ -49,11 +60,32 @@ LIBAPI = 0
 # to 0 if you are raising the major API version
 LIBPATCH = 1
 
+# File path where metrics endpoint change data is written for exchange
+# between the discovery process and the materialised event.
+PAYLOAD_FILE_PATH = "/tmp/metrics-endpoint-payload.json"
+
 
 class MetricsEndpointChangeEvent(EventBase):
     """A custom event for metrics endpoint changes."""
 
-    pass
+    def __init__(self, handle):
+        super().__init__(handle)
+
+        with open(PAYLOAD_FILE_PATH, 'r') as f:
+            self._discovered = json.loads(f.read())
+
+    def snapshot(self):
+        return {"payload": self._discovered}
+
+    def restore(self, snapshot):
+        self._discovered = {}
+
+        if snapshot:
+            self._discovered = snapshot["payload"]
+
+    @property
+    def discovered(self):
+        return self._discovered
 
 
 class MetricsEndpointChangeCharmEvents(CharmEvents):
@@ -71,7 +103,98 @@ class MetricsEndpointObserver(Object):
     Observed endpoint changes cause :class"`MetricsEndpointChangeEvent` to be emitted.
     """
 
-    on = MetricsEndpointChangeCharmEvents()
-
-    def __init__(self, charm: CharmBase):
+    def __init__(self, charm: CharmBase, watch_names):
         super().__init__(charm, "metrics-endpoint-observer")
+
+        self._charm = charm
+        self._observer_pid = 0
+
+        # The names of services that we are interested in for
+        # determining added/removed metrics endpoints.
+        self._watch_names = watch_names
+
+    def start_observer(self):
+        """Start the metrics endpoint observer running in a new process."""
+        self.stop_observer()
+
+        logging.info("Starting metrics endpoint observer process")
+
+        # We need to trick Juju into thinking that we are not running
+        # in a hook context, as Juju will disallow use of juju-run.
+        new_env = os.environ.copy()
+        new_env.pop("JUJU_CONTEXT_ID")
+
+        pid = subprocess.Popen(
+            [
+                "/usr/bin/python3",
+                "lib/charms/observability_libs/v{}/metrics_endpoint_discovery.py".format(LIBAPI),
+                ",".join(self._watch_names),
+                "/var/lib/juju/tools/{}/juju-run".format(self.unit_tag),
+                self._charm.unit.name,
+                self._charm.charm_dir,
+            ],
+            stdout=open("/var/log/discovery.log", "a"),
+            stderr=subprocess.STDOUT,
+            env=new_env,
+        ).pid
+
+        self._observer_pid = pid
+        logging.info("Started metrics endopint observer process with PID {}".format(pid))
+
+    def stop_observer(self):
+        """Stop the running observer process if we have previously started it."""
+        if not self._observer_pid:
+            return
+
+        try:
+            os.kill(self._observer_pid, signal.SIGINT)
+            msg = "Stopped running metrics endpoint observer process with PID {}"
+            logging.info(msg.format(self._observer_pid))
+        except OSError:
+            pass
+
+    @property
+    def unit_tag(self):
+        """Juju-style tag identifying the unit being run by this charm."""
+        unit_num = self._charm.unit.name.split("/")[-1]
+        return "unit-{}-{}".format(self._charm.app.name, unit_num)
+
+
+def write_payload(payload):
+    """Write the input event data to event payload file."""
+    with open(PAYLOAD_FILE_PATH, "w") as f:
+        f.write(json.dumps(payload))
+
+
+def dispatch(run_cmd, unit, charm_dir):
+    """Use the input juju-run command to dispatch a :class:`MetricsEndpointChangeEvent`."""
+    dispatch_sub_cmd = "JUJU_DISPATCH_PATH=hooks/metrics_endpoint_change {}/dispatch"
+    subprocess.run([run_cmd, "-u", unit, dispatch_sub_cmd.format(charm_dir)])
+
+
+def main():
+    """Main watch and dispatch loop.
+
+    Watch the input k8s service names. When changes are detected, write the
+    observed data to the payload file, and dispatch the change event.
+    """
+    watch_names, run_cmd, unit, charm_dir = sys.argv[1:]
+
+    client = Client()
+    key = "app.kubernetes.io/name"
+    to_watch = watch_names.split(",")
+
+    for change, entity in client.watch(Pod, namespace="*", labels={key: to_watch}):
+        meta = entity.metadata
+        payload = {
+            "change": change,
+            "namespace": meta.namespace,
+            "name": meta.name
+        }
+
+        write_payload(payload)
+        dispatch(run_cmd, unit, charm_dir)
+
+
+if __name__ == "__main__":
+    main()

--- a/lib/charms/observability_libs/v0/metrics_endpoint_discovery.py
+++ b/lib/charms/observability_libs/v0/metrics_endpoint_discovery.py
@@ -45,8 +45,8 @@ import os
 import signal
 import subprocess
 import sys
-
 from typing import Dict, Iterable
+
 from lightkube import Client
 from lightkube.resources.core_v1 import Pod
 from ops.charm import CharmBase, CharmEvents
@@ -75,13 +75,15 @@ class MetricsEndpointChangeEvent(EventBase):
     def __init__(self, handle):
         super().__init__(handle)
 
-        with open(PAYLOAD_FILE_PATH, 'r') as f:
+        with open(PAYLOAD_FILE_PATH, "r") as f:
             self._discovered = json.loads(f.read())
 
     def snapshot(self):
+        """Save the event payload data."""
         return {"payload": self._discovered}
 
     def restore(self, snapshot):
+        """Restore the event payload data."""
         self._discovered = {}
 
         if snapshot:
@@ -89,6 +91,7 @@ class MetricsEndpointChangeEvent(EventBase):
 
     @property
     def discovered(self):
+        """Return the payload of detected endpoint changes for this event."""
         return self._discovered
 
 
@@ -193,11 +196,7 @@ def main():
 
     for change, entity in client.watch(Pod, namespace="*", labels=labels):
         meta = entity.metadata
-        payload = {
-            "change": change,
-            "namespace": meta.namespace,
-            "name": meta.name
-        }
+        payload = {"change": change, "namespace": meta.namespace, "name": meta.name}
 
         write_payload(payload)
         dispatch(run_cmd, unit, charm_dir)

--- a/tests/test_metrics_endpoint_discovery.py
+++ b/tests/test_metrics_endpoint_discovery.py
@@ -4,7 +4,6 @@
 import unittest
 
 from charms.observability_libs.v0.metrics_endpoint_discovery import (
-    PAYLOAD_FILE_PATH,
     MetricsEndpointChangeCharmEvents,
     MetricsEndpointObserver,
     write_payload,

--- a/tests/test_metrics_endpoint_discovery.py
+++ b/tests/test_metrics_endpoint_discovery.py
@@ -4,7 +4,10 @@
 import unittest
 
 from charms.observability_libs.v0.metrics_endpoint_discovery import (
+    PAYLOAD_FILE_PATH,
+    MetricsEndpointChangeCharmEvents,
     MetricsEndpointObserver,
+    write_payload,
 )
 from ops.charm import CharmBase
 from ops.model import ActiveStatus
@@ -12,13 +15,14 @@ from ops.testing import Harness
 
 
 class _TestCharm(CharmBase):
+
+    on = MetricsEndpointChangeCharmEvents()
+
     def __init__(self, *args):
         super().__init__(*args)
 
-        self.observer = MetricsEndpointObserver(self)
-        self.framework.observe(
-            self.observer.on.metrics_endpoint_change, self._on_metrics_endpoint_change
-        )
+        self.observer = MetricsEndpointObserver(self, {"app.kubernetes.io/name": ["grafana-k8s"]})
+        self.framework.observe(self.on.metrics_endpoint_change, self._on_metrics_endpoint_change)
 
     def _on_metrics_endpoint_change(self, event):
         self.unit.status = ActiveStatus("metrics endpoints changed")
@@ -31,5 +35,8 @@ class TestMetricsEndpointDiscovery(unittest.TestCase):
     def test_metrics_endpoint_change_event_emitted_handled(self):
         self.harness.begin()
         charm = self.harness.charm
-        charm.observer.on.metrics_endpoint_change.emit()
+
+        write_payload(None)
+        charm.on.metrics_endpoint_change.emit()
+
         self.assertEqual(charm.unit.status, ActiveStatus("metrics endpoints changed"))


### PR DESCRIPTION
## Issue
This patch adds the ability to watch a k8s cluster for events, in order that we can discover potential metrics endpoints for resources not necessarily created by Juju.

## Solution
It works by: 
- Spawning a process that watches the cluster for designated labels.
- Dispatching a custom event back to the charm when it receives events for watched labels.

## Context
This exploits the `juju-run` command, combined with `JUJU_DISPATCH_PATCH` to simulate a custom hook being dispatched to the charm by Juju.

## Testing Instructions
- Apply this patch:
```diff
diff --git a/metadata.yaml b/metadata.yaml
index 877c3cd..6da09f4 100644
--- a/metadata.yaml
+++ b/metadata.yaml
@@ -5,11 +5,6 @@ description: |
   A placeholder charm that contains helpful charm libraries curated by the
   Canonical Observability charm team.
 summary: Collection of Charm Libraries for the Observability charms.
-containers:
-  placeholder:
-    resource: placeholder-image
-
-resources:
-  placeholder-image:
-    type: oci-image
-    description: OCI image for placeholder
+assumes:
+  - juju >= 2.9.23
+  - k8s-api
diff --git a/src/charm.py b/src/charm.py
index 6e815e9..a5bcf37 100755
--- a/src/charm.py
+++ b/src/charm.py
@@ -5,14 +5,41 @@
 
 """A placeholder charm for the Observability libs."""
 
+import json
+import logging
+
+from charms.observability_libs.v0.metrics_endpoint_discovery import (
+    MetricsEndpointChangeCharmEvents,
+    MetricsEndpointObserver,
+)
 from ops.charm import CharmBase
 from ops.main import main
+from ops.model import ActiveStatus
+
+logger = logging.getLogger(__name__)
 
 
 class ObservabilityLibsCharm(CharmBase):
     """Placeholder charm for Observability libs."""
 
-    pass
+    on = MetricsEndpointChangeCharmEvents()
+
+    def __init__(self, *args):
+        super().__init__(*args)
+
+        self._observer = MetricsEndpointObserver(self, {"app.kubernetes.io/name": ["grafana-k8s"]})
+
+        self.framework.observe(self.on.leader_elected, self._on_leader_elected)
+        self.framework.observe(self.on.metrics_endpoint_change, self._on_endpoints_change)
+
+    def _on_leader_elected(self, event):
+        if self.unit.is_leader():
+            self._observer.start_observer()
+        else:
+            self._observer.stop_observer()
+
+    def _on_endpoints_change(self, event):
+        self.unit.status = ActiveStatus(json.dumps(event.discovered))
 
 
 if __name__ == "__main__":
```
- You can then build and deploy the local observability-libs charm.
- Deploy grafana-k8s and see the status of the charm reflect observed events.

## Release Notes
Adds metrics endpoint discoverability module.
