### PR TITLE
Replace leader guard with is_patched guard

### DIFF
--- a/lib/charms/observability_libs/v1/kubernetes_service_patch.py
+++ b/lib/charms/observability_libs/v1/kubernetes_service_patch.py
@@ -125,7 +125,7 @@ LIBAPI = 1
 
 # Increment this PATCH version before using `charmcraft publish-lib` or reset
 # to 0 if you are raising the major API version
-LIBPATCH = 1
+LIBPATCH = 2
 
 ServiceType = Literal["ClusterIP", "LoadBalancer"]
 
@@ -232,7 +232,7 @@ class KubernetesServicePatch(Object):
         Raises:
             PatchFailed: if patching fails due to lack of permissions, or otherwise.
         """
-        if not self.charm.unit.is_leader():
+        if self.is_patched():
             return
 
         client = Client()

--- a/tests/test_kubernetes_service.py
+++ b/tests/test_kubernetes_service.py
@@ -373,13 +373,17 @@ class TestK8sServicePatch(unittest.TestCase):
 
     @patch(f"{MOD_PATH}.Client.patch")
     @patch(f"{MOD_PATH}.ApiError", _FakeApiError)
+    @patch(f"{CL_PATH}.is_patched", lambda *args: False)
     @patch("lightkube.core.client.GenericSyncClient", Mock)
     def test_patch_k8s_service(self, client_patch):
         charm = self.harness.charm
         self.harness.set_leader(False)
         charm.on.install.emit()
-        # Patch shouldn't work on a non-leader unit
-        self.assertEqual(client_patch.call_count, 0)
+        # Patch should work even on a non-leader unit
+        # Check we call the patch method on the client with the correct arguments
+        client_patch.assert_called_with(
+            Service, "test-charm", charm.service_patch.service, patch_type=PatchType.MERGE
+        )
 
         self.harness.set_leader(True)
         charm.on.install.emit()


### PR DESCRIPTION
## Issue
The k8s patching had a leader guard inside on-install, which always happens before leader-elected.
It's possible that juju already elected a leader by the time `install` fires, but it is technically incorrect to assume so.
A unit does not need to be a leader to patch k8s.


## Solution
Use `is_patched` guard instead of leader guard.


## Context
This is only a partial solution so far, because we still get these kind of errors:
```
ERROR juju.worker.caasapplicationprovisioner.runner exited "prometheus-k8s": Operation cannot be fulfilled on pods "prometheus-k8s-0": the object has been modified; please apply your changes to the latest version and try again
```


## Testing Instructions
Deploy e.g. prometheus with this version of the lib.


## Release Notes
Replace leader guard with is_patched guard in k8s patching.
