### PR TITLE
Fix typo in is_valid_uuid regex

### DIFF
--- a/lib/charms/observability_libs/v0/juju_topology.py
+++ b/lib/charms/observability_libs/v0/juju_topology.py
@@ -126,7 +126,25 @@ class JujuTopology:
         self._unit = unit
 
     def is_valid_uuid(self, uuid):
-        """Validates the supplied UUID against the Juju Model UUID pattern."""
+        """Validate the supplied UUID against the Juju Model UUID pattern."""
+        # TODO:
+        # Harness is harcoding an UUID that is v1 not v4: f2c1b2a6-e006-11eb-ba80-0242ac130004
+        # See: https://github.com/canonical/operator/issues/779
+        #
+        # >>> uuid.UUID("f2c1b2a6-e006-11eb-ba80-0242ac130004").version
+        # 1
+        #
+        # we changed the validation of the 3ed UUID block: 4[a-f0-9]{3} -> [a-f0-9]{4}
+        # See: https://github.com/canonical/operator/blob/main/ops/testing.py#L1094
+        #
+        # Juju in fact generates a UUID v4: https://github.com/juju/utils/blob/master/uuid.go#L62
+        # but does not validate it is actually v4:
+        # See:
+        # - https://github.com/juju/utils/blob/master/uuid.go#L22
+        # - https://github.com/juju/schema/blob/master/strings.go#L79
+        #
+        # Once Harness fixes this, we should remove this comment and refactor the regex or
+        # the entire method using the uuid module to validate UUIDs
         regex = re.compile(
             "^[a-f0-9]{8}-?[a-f0-9]{4}-?[a-f0-9]{4}-?[89ab][a-f0-9]{3}-?[a-f0-9]{12}$"
         )

--- a/lib/charms/observability_libs/v0/juju_topology.py
+++ b/lib/charms/observability_libs/v0/juju_topology.py
@@ -128,7 +128,7 @@ class JujuTopology:
     def is_valid_uuid(self, uuid):
         """Validates the supplied UUID against the Juju Model UUID pattern."""
         regex = re.compile(
-            "^[a-f0-9]{8}-?[a-f0-9]{4}-?4[a-f0-9]{3}-?[89ab][a-f0-9]{3}-?[a-f0-9]{12}$"
+            "^[a-f0-9]{8}-?[a-f0-9]{4}-?[a-f0-9]{4}-?[89ab][a-f0-9]{3}-?[a-f0-9]{12}$"
         )
         return bool(regex.match(uuid))
 

--- a/lib/charms/observability_libs/v0/juju_topology.py
+++ b/lib/charms/observability_libs/v0/juju_topology.py
@@ -76,7 +76,7 @@ from typing import Dict, List, Optional
 LIBID = "bced1658f20f49d28b88f61f83c2d232"
 
 LIBAPI = 0
-LIBPATCH = 1
+LIBPATCH = 2
 
 
 class InvalidUUIDError(Exception):

--- a/tests/test_juju_topology.py
+++ b/tests/test_juju_topology.py
@@ -4,7 +4,7 @@ import unittest
 from collections import OrderedDict
 
 import ops
-from charms.observability_libs.v0.juju_topology import JujuTopology
+from charms.observability_libs.v0.juju_topology import InvalidUUIDError, JujuTopology
 from ops.charm import CharmBase
 from ops.testing import Harness
 
@@ -85,6 +85,22 @@ class TestJujuTopologyLib(unittest.TestCase):
     def test_from_dict(self):
         topology = JujuTopology.from_dict(self.input)
         self.assertEqual(topology.as_dict(), self.input)
+
+    def test_invalid_uuid(self):
+        invalid_uuid = "f2c1b2a6-006-11eb-ba80-0242ac130004"
+        topology_invalid_uuid = OrderedDict(
+            [
+                ("model", "some-model"),
+                ("model_uuid", invalid_uuid),
+                ("application", "test-application"),
+                ("unit", "test-application/0"),
+                ("charm_name", "test-application"),
+            ]
+        )
+        with self.assertRaises(InvalidUUIDError) as context:
+            JujuTopology.from_dict(topology_invalid_uuid)
+
+        self.assertTrue(f"'{invalid_uuid}' is not a valid UUID" in str(context.exception))
 
 
 def _filter_dict(labels, excluded_keys):

--- a/tests/test_juju_topology.py
+++ b/tests/test_juju_topology.py
@@ -1,6 +1,7 @@
 # Copyright 2022 Canonical Ltd.
 # See LICENSE file for licensing details.
 import unittest
+import uuid
 from collections import OrderedDict
 
 import ops
@@ -87,20 +88,65 @@ class TestJujuTopologyLib(unittest.TestCase):
         self.assertEqual(topology.as_dict(), self.input)
 
     def test_invalid_uuid(self):
-        invalid_uuid = "f2c1b2a6-006-11eb-ba80-0242ac130004"
-        topology_invalid_uuid = OrderedDict(
-            [
-                ("model", "some-model"),
-                ("model_uuid", invalid_uuid),
-                ("application", "test-application"),
-                ("unit", "test-application/0"),
-                ("charm_name", "test-application"),
-            ]
-        )
-        with self.assertRaises(InvalidUUIDError) as context:
-            JujuTopology.from_dict(topology_invalid_uuid)
+        """Test invalid UUIDs that doesn't match the regex we use."""
+        t_uuid = str(uuid.uuid4()).split("-")
+        block1 = t_uuid[0]
+        block2 = t_uuid[1]
+        block3 = t_uuid[2]
+        block4 = t_uuid[3]
+        block5 = t_uuid[4]
+        sep = "-"
 
-        self.assertTrue(f"'{invalid_uuid}' is not a valid UUID" in str(context.exception))
+        invalid_uuids = [
+            # Invalid character in each block
+            sep.join([block1[:-1] + "ñ", block2, block3, block4, block5]),
+            sep.join([block1, block2[:-1] + "ñ", block3, block4, block5]),
+            sep.join([block1, block2, block3[:-1] + "ñ", block4, block5]),
+            sep.join([block1, block2, block3, block4[:-1] + "ñ", block5]),
+            sep.join([block1, block2, block3, block4, block5[:-1] + "ñ"]),
+            # More characters in each block
+            sep.join([block1 + "a", block2, block3, block4, block5]),
+            sep.join([block1, block2 + "a", block3, block4, block5]),
+            sep.join([block1, block2, block3 + "a", block4, block5]),
+            sep.join([block1, block2, block3, block4 + "a", block5]),
+            sep.join([block1, block2, block3, block4, block5 + "a"]),
+            # Less characters in each block
+            sep.join([block1[:-1], block2, block3, block4, block5]),
+            sep.join([block1, block2[:-1], block3, block4, block5]),
+            sep.join([block1, block2, block3[:-1], block4, block5]),
+            sep.join([block1, block2, block3, block4[:-1], block5]),
+            sep.join([block1, block2, block3, block4, block5[:-1]]),
+            # More than one - in separator
+            (sep * 2).join([block1, block2, block3, block4, block5]),
+            # Missing blocks
+            sep.join([block2, block3, block4, block5]),
+            sep.join([block1, block3, block4, block5]),
+            sep.join([block1, block2, block4, block5]),
+            sep.join([block1, block2, block3, block5]),
+            sep.join([block1, block2, block3, block4]),
+            # UUID v4 validation.
+            # 1st position in block3 must start with 4
+            # Uncomment when Harness issue is fixed
+            # https://github.com/canonical/operator/issues/779
+            # sep.join([block1, block2, "5" + block3[1:], block4, block5]),
+            # 1st position in block4 must start with a, b, 8 or 9
+            sep.join([block1, block2, block3, "w" + block4[1:], block5]),
+        ]
+
+        for invalid_uuid in invalid_uuids:
+            topology_invalid_uuid = OrderedDict(
+                [
+                    ("model", "some-model"),
+                    ("model_uuid", invalid_uuid),
+                    ("application", "test-application"),
+                    ("unit", "test-application/0"),
+                    ("charm_name", "test-application"),
+                ]
+            )
+            with self.assertRaises(InvalidUUIDError) as context:
+                JujuTopology.from_dict(topology_invalid_uuid)
+
+            self.assertEqual(f"'{invalid_uuid}' is not a valid UUID.", str(context.exception))
 
 
 def _filter_dict(labels, excluded_keys):


### PR DESCRIPTION
## Issue
<!-- What issue is this PR trying to solve? -->
This PR fixes #16 

## Solution
<!-- A summary of the solution addressing the above issue -->

Fix a typo in the regex that validates UUID

## Context
<!-- What is some specialized knowledge relevant to this project/technology -->

The change is simple:

```diff
@@ -128,7 +128,7 @@ class JujuTopology:
     def is_valid_uuid(self, uuid):
         """Validates the supplied UUID against the Juju Model UUID pattern."""
         regex = re.compile(
-            "^[a-f0-9]{8}-?[a-f0-9]{4}-?4[a-f0-9]{3}-?[89ab][a-f0-9]{3}-?[a-f0-9]{12}$"
+            "^[a-f0-9]{8}-?[a-f0-9]{4}-?[a-f0-9]{4}-?[89ab][a-f0-9]{3}-?[a-f0-9]{12}$"
         )
         return bool(regex.match(uuid))
```

## Testing Instructions
<!-- What steps need to be taken to test this PR? -->

Run unit test. We added a new one: `test_invalid_uuid`

## Release Notes
<!-- A digestable summary of the change in this PR -->

Fix typo in the regular expression that validates UUID in the method `is_valid_uuid`