### PR TITLE
Fix: Do not crash when using alternative service name

### DIFF
--- a/lib/charms/observability_libs/v1/kubernetes_service_patch.py
+++ b/lib/charms/observability_libs/v1/kubernetes_service_patch.py
@@ -238,10 +238,10 @@ class KubernetesServicePatch(Object):
         except exceptions.ConfigError as e:
             logger.warning("Error creating k8s client: %s", e)
             return
-        if self._is_patched(client):
-            return
 
         try:
+            if self._is_patched(client):
+                return
             if self.service_name != self._app:
                 self._delete_and_create_service(client)
             client.patch(Service, self.service_name, self.service, patch_type=PatchType.MERGE)

--- a/tests/test_kubernetes_service.py
+++ b/tests/test_kubernetes_service.py
@@ -468,7 +468,7 @@ class TestK8sServicePatch(unittest.TestCase):
     @patch(f"{MOD_PATH}.ApiError", _FakeApiError)
     @patch(f"{CL_PATH}._namespace", "test")
     @patch(f"{MOD_PATH}.Client")
-    def test_is_patched_k8s_service_api_error_without_alternative_name(self, client):
+    def test_is_patched_k8s_service_api_error_with_default_name(self, client):
         self.harness.set_leader(False)
 
         client.return_value = client


### PR DESCRIPTION
## Issue
When using an alternative service name, Juju first creates a Service with the name of the app. When checking if the Service is already patched, the library crashes because it is trying to read the Service with the alternative name and it does not exists yet, since it was not patched.


## Solution
This change catches the `ApiError` when checking if the Service is patched and returns `False`.


## Context
N/A


## Testing Instructions
Create a charm with a `KubernetesServicePatch` with a custom service name and deploy it successfully.


## Release Notes
Fix: Do not crash when using alternative service name
