### PR TITLE
Gracefully catch SIGTERMs in KubernetesComputeResourcesPatch

### DIFF
--- a/lib/charms/observability_libs/v0/kubernetes_compute_resources_patch.py
+++ b/lib/charms/observability_libs/v0/kubernetes_compute_resources_patch.py
@@ -103,6 +103,8 @@ References:
 
 import decimal
 import logging
+import signal
+import sys
 from decimal import Decimal
 from math import ceil, floor
 from typing import Callable, Dict, List, Optional, Union
@@ -133,7 +135,7 @@ LIBAPI = 0
 
 # Increment this PATCH version before using `charmcraft publish-lib` or reset
 # to 0 if you are raising the major API version
-LIBPATCH = 1
+LIBPATCH = 2
 
 
 _Decimal = Union[Decimal, float, str, int]  # types that are potentially convertible to Decimal
@@ -399,12 +401,27 @@ class ResourcePatcher:
             resource_reqs, self.get_actual(pod_name)
         )
 
+    def _handle_pod_termination(self, *args) -> None:
+        logger.debug(
+            "KubernetesComputeResourcesPatch was interrupted by a SIGTERM, likely due to "
+            "pod termination during execution of `config-changed`. Exiting gracefully. "
+            "The hook will be re-run"
+        )
+        sys.exit(0)
+
     def apply(self, resource_reqs: ResourceRequirements) -> None:
         """Patch the Kubernetes resources created by Juju to limit cpu or mem."""
         # Need to ignore invalid input, otherwise the StatefulSet gives "FailedCreate" and the
         # charm would be stuck in unknown/lost.
         if self.is_patched(resource_reqs):
             return
+
+        # If it's not patched already, add a handler for SIGTERM prior to patching.
+        # Juju tries to send a SIGTERM to the CRI to exit gracefully when in CAAS mode, then
+        # the hook is re-executed, so we can "safely" trap it here without causing a hook
+        # failure if there is a race, and config-changed will retry (after it is applied and
+        # the pod is rescheduled
+        signal.signal(signal.SIGTERM, self._handle_pod_termination)
 
         self.client.patch(
             StatefulSet,

--- a/lib/charms/observability_libs/v0/kubernetes_compute_resources_patch.py
+++ b/lib/charms/observability_libs/v0/kubernetes_compute_resources_patch.py
@@ -403,9 +403,9 @@ class ResourcePatcher:
 
     def _handle_pod_termination(self, *args) -> None:
         logger.debug(
-            "KubernetesComputeResourcesPatch was interrupted by a SIGTERM, likely due to "
+            "KubernetesComputeResourcesPatch's signal handler caught a SIGTERM, likely due to "
             "pod termination during execution of `config-changed`. Exiting gracefully. "
-            "The hook will be re-run"
+            "The hook being executed will be re-run by Juju once the pod is re-scheduled."
         )
         sys.exit(0)
 
@@ -420,7 +420,7 @@ class ResourcePatcher:
         # Juju tries to send a SIGTERM to the CRI to exit gracefully when in CAAS mode, then
         # the hook is re-executed, so we can "safely" trap it here without causing a hook
         # failure if there is a race, and config-changed will retry (after it is applied and
-        # the pod is rescheduled
+        # the pod is rescheduled)
         signal.signal(signal.SIGTERM, self._handle_pod_termination)
 
         self.client.patch(


### PR DESCRIPTION
## Issue
When the bundle is deployed, with resource limits applied, we are seeing occasional races which result in "random" hooks failing ([`grafana-dashboard-relation-created`](https://github.com/canonical/grafana-k8s-operator/issues/140), @sed-i has seen `leader-elected` and `peer-relation-joined` fail in integration tests, etc). Juju's `caasapplicationterminator` sends a `SIGTERM`, nicely, but without a signal handler, Python bails and we see `hook-failed: foo-bar-baz`

## Solution
If the patch is not already applied, attach a `SIGTERM` handler prior to patching. 

## Context
In case of `SIGTERM` (a tombstone from Juju, really), Juju will re-try the hook, so as long as the charms stay idempotent, there's no risk here either.

## Testing Instructions
It's a race, so unfortunately, it's kind of "fetch the patch and repeatedly try manually until we're reasonably confident" without synthetic integration tests which just sleep with a handler, which don't really prove much other than "Juju behaves" as far as the actual race, and will run up the integration test time without a "real" workflow.

## Release Notes
Gracefully catch SIGTERMs in KubernetesComputeResourcesPatch