### PR TITLE
Update endpoint discovery

### DIFF
--- a/lib/charms/observability_libs/v0/metrics_endpoint_discovery.py
+++ b/lib/charms/observability_libs/v0/metrics_endpoint_discovery.py
@@ -46,7 +46,7 @@ import signal
 import subprocess
 import sys
 from pathlib import Path
-from typing import Dict, Iterable
+from typing import Dict, Iterable, cast
 
 from lightkube import Client
 from lightkube.resources.core_v1 import Pod
@@ -164,15 +164,15 @@ class MetricsEndpointObserver(Object):
             env=new_env,
         ).pid
 
-        self._observer_pid = pid
+        self._observer_pid = pid  # type: ignore
 
     def stop_observer(self):
         """Stop the running observer process if we have previously started it."""
-        if not self._observer_pid:
+        if not self._observer_pid:  # type: ignore
             return
 
         try:
-            os.kill(self._observer_pid, signal.SIGINT)
+            os.kill(self._observer_pid, signal.SIGINT)  # type: ignore
             msg = "Stopped running metrics endpoint observer process with PID {}"
             logging.info(msg.format(self._observer_pid))
         except OSError:

--- a/lib/charms/observability_libs/v0/metrics_endpoint_discovery.py
+++ b/lib/charms/observability_libs/v0/metrics_endpoint_discovery.py
@@ -46,7 +46,7 @@ import signal
 import subprocess
 import sys
 from pathlib import Path
-from typing import Dict, Iterable, cast
+from typing import Dict, Iterable
 
 from lightkube import Client
 from lightkube.resources.core_v1 import Pod

--- a/lib/charms/observability_libs/v0/metrics_endpoint_discovery.py
+++ b/lib/charms/observability_libs/v0/metrics_endpoint_discovery.py
@@ -140,8 +140,8 @@ class MetricsEndpointObserver(Object):
             new_env.pop("JUJU_CONTEXT_ID")
 
         tool_prefix = f"/var/lib/juju/tools/{self.unit_tag}"
-        if juju_run_path := Path(tool_prefix, "juju-run").exists():
-            tool_path = juju_run_path
+        if Path(tool_prefix, "juju-run").exists():
+            tool_path = Path(tool_prefix, "juju-run")
         else:
             tool_path = Path("/usr/bin/juju-exec")
 

--- a/tests/unit/test_kubernetes_compute_resources.py
+++ b/tests/unit/test_kubernetes_compute_resources.py
@@ -74,7 +74,7 @@ class TestKubernetesComputeResourcesPatch(unittest.TestCase):
         self.harness.begin_with_initial_hooks()
 
         # Test invalid quantity values
-        for (cpu, memory) in [
+        for cpu, memory in [
             ("-1", ""),
             ("", "-1Gi"),
             ("-1", "1Gi"),

--- a/tests/unit/test_metrics_endpoint_discovery.py
+++ b/tests/unit/test_metrics_endpoint_discovery.py
@@ -2,6 +2,7 @@
 # See LICENSE file for licensing details.
 
 import unittest
+from unittest.mock import patch
 
 from charms.observability_libs.v0.metrics_endpoint_discovery import (
     MetricsEndpointChangeCharmEvents,
@@ -31,6 +32,10 @@ class TestMetricsEndpointDiscovery(unittest.TestCase):
     def setUp(self) -> None:
         self.harness = Harness(_TestCharm, meta="name: test-charm")
 
+    @patch(
+        "charms.observability_libs.v0.metrics_endpoint_discovery.MetricsEndpointObserver.start_observer",
+        lambda x: True,
+    )
     def test_metrics_endpoint_change_event_emitted_handled(self):
         self.harness.begin()
         charm = self.harness.charm

--- a/tests/unit/test_metrics_endpoint_discovery.py
+++ b/tests/unit/test_metrics_endpoint_discovery.py
@@ -15,7 +15,6 @@ from ops.testing import Harness
 
 
 class _TestCharm(CharmBase):
-
     on = MetricsEndpointChangeCharmEvents()
 
     def __init__(self, *args):


### PR DESCRIPTION
## Issue
`juju-run` is no longer present in juju3, replaced with `juju-exec`. Do it here also.

Start the observer as part of the constructor, and squash the payload so it doesn't get duplicate records sent.
