### PR TITLE
Remove the DeprecationWarning

### DIFF
--- a/lib/charms/observability_libs/v0/juju_topology.py
+++ b/lib/charms/observability_libs/v0/juju_topology.py
@@ -67,7 +67,6 @@ topology = JujuTopology(
 ```
 
 """
-import warnings
 from collections import OrderedDict
 from typing import Dict, List, Optional
 from uuid import UUID
@@ -76,7 +75,7 @@ from uuid import UUID
 LIBID = "bced1658f20f49d28b88f61f83c2d232"
 
 LIBAPI = 0
-LIBPATCH = 5
+LIBPATCH = 6
 
 
 class InvalidUUIDError(Exception):
@@ -120,11 +119,6 @@ class JujuTopology:
             unit: a unit name as a string
             charm_name: name of charm as a string
         """
-        warnings.warn(
-            "observability_libs.v0.juju_topology is deprecated. Use `pip install cosl` instead",
-            category=DeprecationWarning,
-        )
-
         if not self.is_valid_uuid(model_uuid):
             raise InvalidUUIDError(model_uuid)
 

--- a/tests/unit/test_juju_topology.py
+++ b/tests/unit/test_juju_topology.py
@@ -153,26 +153,3 @@ class TestJujuTopologyLib(unittest.TestCase):
 
 def _filter_dict(labels, excluded_keys):
     return OrderedDict({k: v for k, v in labels.items() if k not in excluded_keys})
-
-
-class TestDeprecationWarning(unittest.TestCase):
-    def setUp(self):
-        self.input = OrderedDict(
-            [
-                ("model", "some-model"),
-                ("model_uuid", "00000000-0000-4000-8000-000000000000"),
-                ("application", "test-application"),
-                ("unit", "test-application/0"),
-                ("charm_name", "test-application"),
-            ]
-        )
-
-    def test_class_deprecated(self):
-        with self.assertWarns(DeprecationWarning):
-            JujuTopology(
-                self.input["model"],
-                self.input["model_uuid"],
-                self.input["application"],
-                self.input["unit"],
-                self.input["charm_name"],
-            )


### PR DESCRIPTION
## Issue
We're not releasing for a bit while we work on other things, and the `DeprecationWarning` flags almost every time this is instantiated. 

Get rid of it until we're ready.
