### PR TITLE
simplify logic, remove stored state dep, fix mem leak

### DIFF
--- a/lib/charms/observability_libs/v0/metrics_endpoint_discovery.py
+++ b/lib/charms/observability_libs/v0/metrics_endpoint_discovery.py
@@ -62,7 +62,7 @@ LIBAPI = 0
 
 # Increment this PATCH version before using `charmcraft publish-lib` or reset
 # to 0 if you are raising the major API version
-LIBPATCH = 3
+LIBPATCH = 4
 
 # File path where metrics endpoint change data is written for exchange
 # between the discovery process and the materialised event.

--- a/lib/charms/observability_libs/v0/metrics_endpoint_discovery.py
+++ b/lib/charms/observability_libs/v0/metrics_endpoint_discovery.py
@@ -162,7 +162,7 @@ class MetricsEndpointObserver(Object):
     def stop_observers(self):
         """Stops all running instances of the observer."""
         logging.info("Stopping all running metrics endpoint observer processes")
-        subprocess.run(["pkill", "--signal", "INT", "-f", ".*metrics_endpoint.*"])
+        subprocess.run(["pkill", "--signal", "INT", "-f", ".*lib/charms/observability_libs/v[0-9]/metrics_endpoint_discovery\.py.*"])
 
     @property
     def unit_tag(self):

--- a/lib/charms/observability_libs/v0/metrics_endpoint_discovery.py
+++ b/lib/charms/observability_libs/v0/metrics_endpoint_discovery.py
@@ -162,7 +162,15 @@ class MetricsEndpointObserver(Object):
     def stop_observers(self):
         """Stops all running instances of the observer."""
         logging.info("Stopping all running metrics endpoint observer processes")
-        subprocess.run(["pkill", "--signal", "INT", "-f", ".*lib/charms/observability_libs/v[0-9]/metrics_endpoint_discovery\.py.*"])
+        subprocess.run(
+            [
+                "pkill",
+                "--signal",
+                "INT",
+                "-f",
+                r".*lib/charms/observability_libs/v[0-9]/metrics_endpoint_discovery\.py.*",
+            ]
+        )
 
     @property
     def unit_tag(self):

--- a/tox.ini
+++ b/tox.ini
@@ -93,8 +93,7 @@ commands =
 [testenv:integration]
 description = Run integration tests
 deps =
-    # Need to pin pylibjuju due to https://github.com/juju/python-libjuju/issues/770
-    juju < 3.1
+    juju ~= 3.1.0
     lightkube
     lightkube-models
     pytest


### PR DESCRIPTION
## Issue
<!-- What issue is this PR trying to solve? -->
https://github.com/canonical/seldon-core-operator/issues/123 
Every event processed by the charm lead to another process instance.


## Solution
<!-- A summary of the solution addressing the above issue -->
Fixes the issue by removing the need for pid juggling and instead doing a blanket `pkill` for everything that matches our invocation. 

## Context
<!-- What is some specialized knowledge relevant to this project/technology -->
N/A

## Testing Instructions
<!-- What steps need to be taken to test this PR? -->
1. Copy lib to seldon-core
2. Deploy seldon-core
3. Check `ps ax` for duplicate processes

## Release Notes
<!-- A digestable summary of the change in this PR -->
