### PR TITLE
include update_status in default refresh events

### DIFF
--- a/lib/charms/observability_libs/v1/kubernetes_service_patch.py
+++ b/lib/charms/observability_libs/v1/kubernetes_service_patch.py
@@ -202,7 +202,7 @@ class KubernetesServicePatch(Object):
         self.framework.observe(charm.on.install, self._patch)
         self.framework.observe(charm.on.upgrade_charm, self._patch)
         self.framework.observe(charm.on.update_status, self._patch)
-        
+
         # apply user defined events
         if refresh_event:
             if not isinstance(refresh_event, list):

--- a/lib/charms/observability_libs/v1/kubernetes_service_patch.py
+++ b/lib/charms/observability_libs/v1/kubernetes_service_patch.py
@@ -201,7 +201,8 @@ class KubernetesServicePatch(Object):
         # Ensure this patch is applied during the 'install' and 'upgrade-charm' events
         self.framework.observe(charm.on.install, self._patch)
         self.framework.observe(charm.on.upgrade_charm, self._patch)
-
+        self.framework.observe(charm.on.update_status, self._patch)
+        
         # apply user defined events
         if refresh_event:
             if not isinstance(refresh_event, list):


### PR DESCRIPTION
## Issue
<!-- What issue is this PR trying to solve? -->
If something alters the state of the kubernetes service patch, there currently is no passive refresh event that could serve as an initiator for self-healing.

## Solution
<!-- A summary of the solution addressing the above issue -->
Also observe `update_status` as a refresh event.

## Context
<!-- What is some specialized knowledge relevant to this project/technology -->

## Testing Instructions
<!-- What steps need to be taken to test this PR? -->
1. deploy cos
2. make sure the traefik service is patched
3. `kubectl rollout restart sts/controller -n <your-controller-namespace>`
4. see traefik service reverting to `ClusterIP`
5. wait for `update_status`
6. verify the services is back to being a `LoadBalancer` 

## Release Notes
<!-- A digestable summary of the change in this PR -->
Observe `update_status` as a refresh event by default.