### PR TITLE
Strip the CSR from event for correct comparison

### DIFF
--- a/lib/charms/observability_libs/v0/cert_handler.py
+++ b/lib/charms/observability_libs/v0/cert_handler.py
@@ -257,7 +257,11 @@ class CertHandler(Object):
         # relation-changed. If that is not the case, we would need more guards and more paths.
 
         # Process the cert only if it belongs to the unit that requested it (this unit)
-        event_csr = event.certificate_signing_request.strip() if event.certificate_signing_request else None
+        event_csr = (
+            event.certificate_signing_request.strip()
+            if event.certificate_signing_request
+            else None
+        )
         if event_csr == self._csr:
             self._ca_cert = event.ca
             self._server_cert = event.certificate

--- a/lib/charms/observability_libs/v0/cert_handler.py
+++ b/lib/charms/observability_libs/v0/cert_handler.py
@@ -62,7 +62,7 @@ logger = logging.getLogger(__name__)
 
 LIBID = "b5cd5cd580f3428fa5f59a8876dcbe6a"
 LIBAPI = 0
-LIBPATCH = 2
+LIBPATCH = 3
 
 
 class CertChanged(EventBase):

--- a/lib/charms/observability_libs/v0/cert_handler.py
+++ b/lib/charms/observability_libs/v0/cert_handler.py
@@ -257,7 +257,8 @@ class CertHandler(Object):
         # relation-changed. If that is not the case, we would need more guards and more paths.
 
         # Process the cert only if it belongs to the unit that requested it (this unit)
-        if event.certificate_signing_request == self._csr:
+        event_csr = event.certificate_signing_request.strip() if event.certificate_signing_request else None
+        if event_csr == self._csr:
             self._ca_cert = event.ca
             self._server_cert = event.certificate
             self._chain = event.chain


### PR DESCRIPTION
## Issue
No certs appear in relation data because the comparison `if event.certificate_signing_request == self._csr:` was always failing: the event CSR has a trailing `\n`.


## Solution
Strip the CSR from event for correct comparison.


## Context
<!-- What is some specialized knowledge relevant to this project/technology -->


## Testing Instructions
- Relate self-signed-certificates to [alertmanager/171](https://github.com/canonical/alertmanager-k8s-operator/pull/171).
- Before this PR, `juju show-unit alertmanager/0` shows only the private key. With this change, it also includes the cert.


## Release Notes
Strip the CSR from event for correct comparison.
