### PR TITLE
Add info log line for csr dns

### DIFF
--- a/lib/charms/observability_libs/v0/cert_handler.py
+++ b/lib/charms/observability_libs/v0/cert_handler.py
@@ -108,7 +108,10 @@ class CertHandler(Object):
         self.charm = charm
         self.cert_subject = cert_subject or charm.unit.name
         self.cert_subject = charm.unit.name if not cert_subject else cert_subject
-        self.extra_sans_dns = list(filter(None, extra_sans_dns or []))  # drop empty list items
+
+        # Auto-include the fqdn and drop empty/duplicate sans
+        self.sans_dns = list(set(filter(None, (extra_sans_dns or []) + [socket.getfqdn()])))
+
         self.peer_relation_name = peer_relation_name
         self.certificates_relation_name = certificates_relation_name
 
@@ -221,11 +224,10 @@ class CertHandler(Object):
         if overwrite or renew or not self._csr:
             private_key = self._private_key
             assert private_key is not None  # for type checker
-            sans_dns = [socket.getfqdn()] + self.extra_sans_dns
             csr = generate_csr(
                 private_key=private_key.encode(),
                 subject=self.cert_subject,
-                sans_dns=sans_dns,
+                sans_dns=self.sans_dns,
             )
 
             if renew and self._csr:
@@ -234,7 +236,7 @@ class CertHandler(Object):
                     new_certificate_signing_request=csr,
                 )
             else:
-                logger.info("Creating CSR for %s with DNS %s", self.cert_subject, sans_dns)
+                logger.info("Creating CSR for %s with DNS %s", self.cert_subject, self.sans_dns)
                 self.certificates.request_certificate_creation(certificate_signing_request=csr)
 
             # Note: CSR is being replaced with a new one, so until we get the new cert, we'd have

--- a/lib/charms/observability_libs/v0/cert_handler.py
+++ b/lib/charms/observability_libs/v0/cert_handler.py
@@ -62,7 +62,7 @@ logger = logging.getLogger(__name__)
 
 LIBID = "b5cd5cd580f3428fa5f59a8876dcbe6a"
 LIBAPI = 0
-LIBPATCH = 3
+LIBPATCH = 4
 
 
 class CertChanged(EventBase):
@@ -221,10 +221,11 @@ class CertHandler(Object):
         if overwrite or renew or not self._csr:
             private_key = self._private_key
             assert private_key is not None  # for type checker
+            sans_dns = [socket.getfqdn()] + self.extra_sans_dns
             csr = generate_csr(
                 private_key=private_key.encode(),
                 subject=self.cert_subject,
-                sans_dns=[socket.getfqdn()] + self.extra_sans_dns,
+                sans_dns=sans_dns,
             )
 
             if renew and self._csr:
@@ -233,6 +234,7 @@ class CertHandler(Object):
                     new_certificate_signing_request=csr,
                 )
             else:
+                logger.info("Creating CSR for %s with DNS %s", self.cert_subject, sans_dns)
                 self.certificates.request_certificate_creation(certificate_signing_request=csr)
 
             # Note: CSR is being replaced with a new one, so until we get the new cert, we'd have


### PR DESCRIPTION
## Issue
No log line for the DNS we're sending a CSR for.
We could look at `juju show-unit` and `openssl` output but this is easier.


## Solution
Add log line for the csr dns.


## Context
Handy for manually testing https://github.com/canonical/traefik-k8s-operator/pull/196.


## Testing Instructions
NTA.


## Release Notes
Add info log line for csr dns.
