### PR TITLE
Sanitize unit name in cert subject

### DIFF
--- a/lib/charms/observability_libs/v0/cert_handler.py
+++ b/lib/charms/observability_libs/v0/cert_handler.py
@@ -106,8 +106,9 @@ class CertHandler(Object):
         super().__init__(charm, key)
 
         self.charm = charm
-        self.cert_subject = cert_subject or charm.unit.name
-        self.cert_subject = charm.unit.name if not cert_subject else cert_subject
+        # We need to sanitize the unit name, otherwise route53 complains:
+        # "urn:ietf:params:acme:error:malformed" :: Domain name contains an invalid character
+        self.cert_subject = charm.unit.name.replace("/", "-") if not cert_subject else cert_subject
 
         # Use fqdn only if no SANs were given, and drop empty/duplicate SANs
         self.sans_dns = list(set(filter(None, (extra_sans_dns or [socket.getfqdn()]))))

--- a/lib/charms/observability_libs/v0/cert_handler.py
+++ b/lib/charms/observability_libs/v0/cert_handler.py
@@ -62,7 +62,7 @@ logger = logging.getLogger(__name__)
 
 LIBID = "b5cd5cd580f3428fa5f59a8876dcbe6a"
 LIBAPI = 0
-LIBPATCH = 6
+LIBPATCH = 7
 
 
 class CertChanged(EventBase):


### PR DESCRIPTION
## Issue
Route53 [complains](https://github.com/canonical/traefik-k8s-operator/issues/214):
```
problem: "urn:ietf:params:acme:error:malformed" :: Error creating new order :: Domain name contains an invalid character
```

## Solution
Do not include`/` in CN.


## Release Notes
Sanitize unit name in cert subject.
