### PR TITLE
fixed issue where privkey would be unset if relation creation order i…

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,5 +10,4 @@ build/
 .tox/
 .mypy_cache
 .vscode
-/lib/charms/tls_certificates_interface
 *.egg-info/

--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,5 @@ build/
 .tox/
 .mypy_cache
 .vscode
+/lib/charms/tls_certificates_interface
+*.egg-info/

--- a/lib/charms/observability_libs/v0/cert_handler.py
+++ b/lib/charms/observability_libs/v0/cert_handler.py
@@ -169,30 +169,7 @@ class CertHandler(Object):
 
     def _on_peer_relation_created(self, _):
         """Generate the CSR if the certificates relation is ready."""
-        self._generate_csr_if_ready()
-
-    def _on_certificates_relation_joined(self, _) -> None:
-        """Generate the CSR if the peer relation is ready."""
-        self._generate_csr_if_ready()
-
-    def _generate_privkey(self):
-        # Generate priv key unless done already
-        # TODO figure out how to go about key rotation.
-        if not self._private_key:
-            private_key = generate_private_key()
-            self._private_key = private_key.decode()
-
-    def _generate_csr_if_ready(self):
-        """Common exit hook for peer and certificates relation-created/joined flows."""
         self._generate_privkey()
-        # check that peer and cert relations are in place
-        # todo: compound status would be handy here to set waiting in either case
-        # check peer relation is there
-        if not self._peer_relation:
-            # tls-certificates relation event happened to fire before peer events.
-            # Abort, and let the "peer joined" relation create the CSR.
-            logger.info("certhandler waiting on peer relation")
-            return
 
         # check cert relation is ready
         if not (self.charm.model.get_relation(self.certificates_relation_name)):
@@ -203,6 +180,27 @@ class CertHandler(Object):
 
         logger.debug("certhandler has peer and certs relation: proceeding to generate csr")
         self._generate_csr()
+
+    def _on_certificates_relation_joined(self, _) -> None:
+        """Generate the CSR if the peer relation is ready."""
+        self._generate_privkey()
+
+        # check peer relation is there
+        if not self._peer_relation:
+            # tls-certificates relation event happened to fire before peer events.
+            # Abort, and let the "peer joined" relation create the CSR.
+            logger.info("certhandler waiting on peer relation")
+            return
+
+        logger.debug("certhandler has peer and certs relation: proceeding to generate csr")
+        self._generate_csr()
+
+    def _generate_privkey(self):
+        # Generate priv key unless done already
+        # TODO figure out how to go about key rotation.
+        if not self._private_key:
+            private_key = generate_private_key()
+            self._private_key = private_key.decode()
 
     def _on_config_changed(self, _):
         # FIXME on config changed, the web_external_url may or may not change. But because every
@@ -234,6 +232,8 @@ class CertHandler(Object):
         if overwrite or renew or not self._csr:
             private_key = self._private_key
             if private_key is None:
+                # FIXME: raise this in a less nested scope by
+                #  generating privkey and csr in the same method.
                 raise RuntimeError(
                     "private key unset. call _generate_privkey() before you call this method."
                 )

--- a/tests/scenario/test_cert_handler/test_cert_handler.py
+++ b/tests/scenario/test_cert_handler/test_cert_handler.py
@@ -1,0 +1,52 @@
+import sys
+from pathlib import Path
+
+import pytest
+from ops import CharmBase
+from scenario import Context, PeerRelation, Relation, State
+
+libs = str(Path(__file__).parent.parent.parent.parent / "lib")
+sys.path.append(libs)
+
+from lib.charms.observability_libs.v0.cert_handler import CertHandler  # noqa E402
+
+
+class MyCharm(CharmBase):
+    META = {
+        "name": "fabio",
+        "requires": {"certificates": {"interface": "certificates"}},
+        "peers": {"replicas": {"interface": "replicas"}},
+    }
+
+    def __init__(self, fw):
+        super().__init__(fw)
+        self.ch = CertHandler(self, key="ch", peer_relation_name="replicas")
+
+
+@pytest.fixture
+def ctx():
+    return Context(MyCharm, MyCharm.META)
+
+
+@pytest.fixture
+def peer():
+    return PeerRelation("replicas")
+
+
+@pytest.fixture
+def certificates():
+    return Relation("certificates")
+
+
+def test_cert_joins(ctx, peer, certificates):
+    # both peer and certificates are there, we're processing certificates-joined
+    with ctx.manager(certificates.joined_event, State(relations=[peer, certificates])) as runner:
+        runner.run()
+        assert runner.charm.ch._private_key
+
+
+def test_peer_created(ctx, peer, certificates):
+    # both peer and certificates are there, we're processing peer-created
+    with ctx.manager(peer.created_event, State(relations=[peer, certificates])) as runner:
+        runner.run()
+        assert runner.charm.ch._private_key

--- a/tox.ini
+++ b/tox.ini
@@ -101,5 +101,10 @@ deps =
     cryptography
     jsonschema
     -r{toxinidir}/requirements.txt
+allowlist_externals =
+    charmcraft
+    rm
 commands =
+    charmcraft fetch-lib charms.tls_certificates_interface.v2.tls_certificates
     pytest -v --tb native {[vars]tst_path}/scenario --log-cli-level=INFO -s {posargs}
+    rm -rf ./lib/charms/tls_certificates_interface

--- a/tox.ini
+++ b/tox.ini
@@ -92,3 +92,14 @@ deps =
     pytest-operator
 commands =
     pytest -v --tb native --log-cli-level=INFO -s {posargs} {toxinidir}/tests/integration
+
+[testenv:scenario]
+description = Scenario tests
+deps =
+    pytest
+    ops-scenario >= 5.1
+    cryptography
+    jsonschema
+    -r{toxinidir}/requirements.txt
+commands =
+    pytest -v --tb native {[vars]tst_path}/scenario --log-cli-level=INFO -s {posargs}

--- a/tox.ini
+++ b/tox.ini
@@ -94,7 +94,10 @@ commands =
     pytest -v --tb native --log-cli-level=INFO -s {posargs} {toxinidir}/tests/integration
 
 [testenv:scenario]
-description = Scenario tests
+description = Scenario tests (CI satisfaction placeholder)
+
+[testenv:scenario-manual]
+description = Scenario tests (manual only: GH runner does not like charmcraft fetch-lib)
 deps =
     pytest
     ops-scenario >= 5.1


### PR DESCRIPTION
Fixes #50 

I suspect this happens because we don't setup the privkey if, unexpectedly, certificates-created fires before peer-relation-joined does.
