### PR TITLE
Split SANs into DNS and IP

### DIFF
--- a/charmcraft.yaml
+++ b/charmcraft.yaml
@@ -11,5 +11,7 @@ bases:
         channel: "20.04"
 parts:
   charm:
+    charm-binary-python-packages:
+      - httpx  # https://github.com/pypa/setuptools_scm/issues/918
     build-packages:
       - git

--- a/tox.ini
+++ b/tox.ini
@@ -82,6 +82,8 @@ commands =
       -m pytest -v --tb native --log-cli-level=INFO -s {posargs} {[vars]tst_path}/unit
     coverage report
 
+[testenv:scenario]
+
 [testenv:integration]
 description = Run integration tests
 deps =


### PR DESCRIPTION
## Issue
When traefik generates a CSR with IP address (this is often the case in testing), then the IP address goes into the DNS section, but according to [RFC 2818](https://www.rfc-editor.org/rfc/rfc2818) ([via](https://stackoverflow.com/a/9200012/3516684)) it needs to go to a different, dedicated section:

>   In some cases, the URI is specified as an IP address rather than a
>   hostname. In this case, the iPAddress subjectAltName must be present
>   in the certificate and must exactly match the IP in the URI.


## Solution
Keep cert_handler API the same, but internally split the list into ips and hostnames and pass accordingly to `generate_csr`.

Tandem PRs:
- https://github.com/canonical/traefik-k8s-operator/pull/245
- https://github.com/canonical/cos-lite-bundle/pull/80
- https://github.com/canonical/traefik-k8s-operator/pull/249

Possibly depends on:
- https://github.com/canonical/tls-certificates-interface/issues/71

## Context
NTA.

## Testing Instructions
Deploy the tandem PRs. Then copy over the external-ca cert, and attempt to curl prometheus via its ingress url, from within the grafana container.

```bash
juju run external-ca/0 get-ca-certificate --format json | jq -r '."external-ca/0".results."ca-certificate"' > external-ca.crt
openssl x509 -noout -text -in external-ca.crt

echo | openssl s_client -showcerts -servername 10.43.8.206 -connect 10.43.8.206:443 | openssl x509 -text -noout

juju scp --container prometheus external-ca.crt prometheus/0:/usr/local/share/ca-certificates
juju ssh --container prometheus prometheus/0 update-ca-certificates --fresh

juju scp --container grafana external-ca.crt grafana/0:/usr/local/share/ca-certificates
juju ssh --container grafana grafana/0 update-ca-certificates --fresh

juju ssh --container grafana grafana/0 curl https://10.43.8.206/trfk-prometheus-0/api/v1/targets | jq | grep -E "scrapeUrl|health"

# from within the grafana workload container, from /usr/local/share/ca-certificates
openssl verify -CAfile $PWD/external-ca.crt -CApath $PWD -verbose -x509_strict -verify_ip ip
```

Before https://github.com/canonical/traefik-k8s-operator/pull/249, curl gives `curl: (60) SSL certificate problem: self-signed certificate` and `openssl verify` complains:
```
error 85 at 0 depth lookup: Missing Authority Key Identifier
C = US, CN = external.demo.ca
error 92 at 1 depth lookup: CA cert does not include key usage extension
error stdin: verification failed
```

With the default cert set in traefik, it works.


## Release Notes
Split SANs into DNS and IP.
