### PR TITLE
[resource-limits] Add `last_error` public attribute, to enable charm to use collect-status

### DIFF
--- a/lib/charms/observability_libs/v0/kubernetes_compute_resources_patch.py
+++ b/lib/charms/observability_libs/v0/kubernetes_compute_resources_patch.py
@@ -541,10 +541,13 @@ class KubernetesComputeResourcesPatch(Object):
         except ValueError as e:
             msg = f"Failed obtaining resource limit spec: {e}"
             logger.error(msg)
+            self.last_error = msg
             return False
 
         if not is_valid_spec(limits) or not is_valid_spec(requests):
-            logger.error("Invalid resource requirements specs: %s, %s", limits, requests)
+            msg = f"Invalid resource requirements specs: {limits}, {requests}"
+            logger.error(msg)
+            self.last_error = msg
             return False
 
         resource_reqs = ResourceRequirements(

--- a/lib/charms/observability_libs/v0/kubernetes_compute_resources_patch.py
+++ b/lib/charms/observability_libs/v0/kubernetes_compute_resources_patch.py
@@ -123,7 +123,7 @@ from lightkube.utils.quantity import equals_canonically, parse_quantity
 from ops import CollectStatusEvent
 from ops.charm import CharmBase
 from ops.framework import BoundEvent, EventBase, EventSource, Object, ObjectEvents
-from ops.model import BlockedStatus
+from ops.model import BlockedStatus, WaitingStatus
 
 logger = logging.getLogger(__name__)
 
@@ -475,6 +475,11 @@ class KubernetesComputeResourcesPatch(Object):
     def _on_collect_unit_status(self, event: CollectStatusEvent):
         if self.last_error:
             event.add_status(BlockedStatus(f"[resource patch] {self.last_error}"))
+
+        if not self.is_ready():
+            event.add_status(
+                WaitingStatus("[resource patch] Waiting for resource limit patch to apply")
+            )
 
     def _on_config_changed(self, _):
         self._patch()

--- a/lib/charms/observability_libs/v0/kubernetes_compute_resources_patch.py
+++ b/lib/charms/observability_libs/v0/kubernetes_compute_resources_patch.py
@@ -120,8 +120,10 @@ from lightkube.resources.apps_v1 import StatefulSet
 from lightkube.resources.core_v1 import Pod
 from lightkube.types import PatchType
 from lightkube.utils.quantity import equals_canonically, parse_quantity
+from ops import CollectStatusEvent
 from ops.charm import CharmBase
 from ops.framework import BoundEvent, EventBase, EventSource, Object, ObjectEvents
+from ops.model import BlockedStatus
 
 logger = logging.getLogger(__name__)
 
@@ -135,6 +137,9 @@ LIBAPI = 0
 # to 0 if you are raising the major API version
 LIBPATCH = 5
 
+PYDEPS = [
+    "ops>=2.5",  # collect_status
+]
 
 _Decimal = Union[Decimal, float, str, int]  # types that are potentially convertible to Decimal
 
@@ -464,6 +469,13 @@ class KubernetesComputeResourcesPatch(Object):
         for ev in refresh_event:
             self.framework.observe(ev, self._on_config_changed)
 
+        self.last_error: Optional[str] = None
+        self.framework.observe(charm.on.collect_unit_status, self._on_collect_unit_status)
+
+    def _on_collect_unit_status(self, event: CollectStatusEvent):
+        if self.last_error:
+            event.add_status(BlockedStatus(f"[resource patch] {self.last_error}"))
+
     def _on_config_changed(self, _):
         self._patch()
 
@@ -476,6 +488,7 @@ class KubernetesComputeResourcesPatch(Object):
         except ValueError as e:
             msg = f"Failed obtaining resource limit spec: {e}"
             logger.error(msg)
+            self.last_error = msg
             self.on.patch_failed.emit(message=msg)
             return
 
@@ -483,6 +496,7 @@ class KubernetesComputeResourcesPatch(Object):
             if not is_valid_spec(spec):
                 msg = f"Invalid resource limit spec: {spec}"
                 logger.error(msg)
+                self.last_error = msg
                 self.on.patch_failed.emit(message=msg)
                 return
 
@@ -497,6 +511,7 @@ class KubernetesComputeResourcesPatch(Object):
         except exceptions.ConfigError as e:
             msg = f"Error creating k8s client: {e}"
             logger.error(msg)
+            self.last_error = msg
             self.on.patch_failed.emit(message=msg)
             return
 
@@ -507,11 +522,13 @@ class KubernetesComputeResourcesPatch(Object):
                 msg = f"Kubernetes resources patch failed: {e}"
 
             logger.error(msg)
+            self.last_error = msg
             self.on.patch_failed.emit(message=msg)
 
         except ValueError as e:
             msg = f"Kubernetes resources patch failed: {e}"
             logger.error(msg)
+            self.last_error = msg
             self.on.patch_failed.emit(message=msg)
 
         else:
@@ -551,6 +568,7 @@ class KubernetesComputeResourcesPatch(Object):
         except (ValueError, ApiError) as e:
             msg = f"Failed to apply resource limit patch: {e}"
             logger.error(msg)
+            self.last_error = msg
             self.on.patch_failed.emit(message=msg)
             return False
 

--- a/lib/charms/observability_libs/v0/kubernetes_compute_resources_patch.py
+++ b/lib/charms/observability_libs/v0/kubernetes_compute_resources_patch.py
@@ -120,10 +120,8 @@ from lightkube.resources.apps_v1 import StatefulSet
 from lightkube.resources.core_v1 import Pod
 from lightkube.types import PatchType
 from lightkube.utils.quantity import equals_canonically, parse_quantity
-from ops import CollectStatusEvent
 from ops.charm import CharmBase
 from ops.framework import BoundEvent, EventBase, EventSource, Object, ObjectEvents
-from ops.model import BlockedStatus, WaitingStatus
 
 logger = logging.getLogger(__name__)
 
@@ -136,10 +134,6 @@ LIBAPI = 0
 # Increment this PATCH version before using `charmcraft publish-lib` or reset
 # to 0 if you are raising the major API version
 LIBPATCH = 5
-
-PYDEPS = [
-    "ops>=2.5",  # collect_status
-]
 
 _Decimal = Union[Decimal, float, str, int]  # types that are potentially convertible to Decimal
 
@@ -470,16 +464,6 @@ class KubernetesComputeResourcesPatch(Object):
             self.framework.observe(ev, self._on_config_changed)
 
         self.last_error: Optional[str] = None
-        self.framework.observe(charm.on.collect_unit_status, self._on_collect_unit_status)
-
-    def _on_collect_unit_status(self, event: CollectStatusEvent):
-        if self.last_error:
-            event.add_status(BlockedStatus(f"[resource patch] {self.last_error}"))
-
-        if not self.is_ready():
-            event.add_status(
-                WaitingStatus("[resource patch] Waiting for resource limit patch to apply")
-            )
 
     def _on_config_changed(self, _):
         self._patch()


### PR DESCRIPTION
## Issue
Status updates are communicated via custom events.

## Solution
Add `last_error` public attribute, to enable charm to [collect-status](https://github.com/canonical/operator/pull/954).

In tandem with:
- https://github.com/canonical/alertmanager-k8s-operator/pull/202
