### PR TITLE
fix race condition in privkey generation

### DIFF
--- a/lib/charms/observability_libs/v0/kubernetes_compute_resources_patch.py
+++ b/lib/charms/observability_libs/v0/kubernetes_compute_resources_patch.py
@@ -133,7 +133,7 @@ LIBAPI = 0
 
 # Increment this PATCH version before using `charmcraft publish-lib` or reset
 # to 0 if you are raising the major API version
-LIBPATCH = 6
+LIBPATCH = 7
 
 
 _Decimal = Union[Decimal, float, str, int]  # types that are potentially convertible to Decimal
@@ -364,7 +364,7 @@ class ResourcePatcher:
         Returns:
             bool: A boolean indicating if the service patch has been applied.
         """
-        return equals_canonically(self.get_templated(), resource_reqs)
+        return equals_canonically(self.get_templated(), resource_reqs)  # pyright: ignore
 
     def get_templated(self) -> Optional[ResourceRequirements]:
         """Returns the resource limits specified in the StatefulSet template."""
@@ -397,8 +397,8 @@ class ResourcePatcher:
             self.get_templated(),
             self.get_actual(pod_name),
         )
-        return self.is_patched(resource_reqs) and equals_canonically(
-            resource_reqs, self.get_actual(pod_name)
+        return self.is_patched(resource_reqs) and equals_canonically(  # pyright: ignore
+             resource_reqs, self.get_actual(pod_name)  # pyright: ignore
         )
 
     def apply(self, resource_reqs: ResourceRequirements) -> None:

--- a/lib/charms/observability_libs/v0/kubernetes_compute_resources_patch.py
+++ b/lib/charms/observability_libs/v0/kubernetes_compute_resources_patch.py
@@ -398,7 +398,7 @@ class ResourcePatcher:
             self.get_actual(pod_name),
         )
         return self.is_patched(resource_reqs) and equals_canonically(  # pyright: ignore
-             resource_reqs, self.get_actual(pod_name)  # pyright: ignore
+            resource_reqs, self.get_actual(pod_name)  # pyright: ignore
         )
 
     def apply(self, resource_reqs: ResourceRequirements) -> None:

--- a/lib/charms/observability_libs/v0/metrics_endpoint_discovery.py
+++ b/lib/charms/observability_libs/v0/metrics_endpoint_discovery.py
@@ -62,7 +62,7 @@ LIBAPI = 0
 
 # Increment this PATCH version before using `charmcraft publish-lib` or reset
 # to 0 if you are raising the major API version
-LIBPATCH = 6
+LIBPATCH = 7
 
 # File path where metrics endpoint change data is written for exchange
 # between the discovery process and the materialised event.
@@ -215,7 +215,7 @@ def main():
 
         target_ports = []
         for c in filter(lambda c: c.ports is not None, entity.spec.containers):  # pyright: ignore
-            for p in filter(lambda p: p.name == "metrics", c.ports):
+            for p in filter(lambda p: p.name == "metrics", c.ports):  # pyright: ignore
                 target_ports.append("*:{}".format(p.containerPort))
 
         payload = {

--- a/lib/charms/observability_libs/v1/cert_handler.py
+++ b/lib/charms/observability_libs/v1/cert_handler.py
@@ -211,6 +211,7 @@ class CertHandler(Object):
         if not relation:
             return
 
+        self._generate_privkey()
         self._generate_csr(renew=True)
 
     def _generate_csr(

--- a/lib/charms/observability_libs/v1/cert_handler.py
+++ b/lib/charms/observability_libs/v1/cert_handler.py
@@ -66,7 +66,7 @@ logger = logging.getLogger(__name__)
 
 LIBID = "b5cd5cd580f3428fa5f59a8876dcbe6a"
 LIBAPI = 1
-LIBPATCH = 1
+LIBPATCH = 2
 
 
 def is_ip_address(value: str) -> bool:


### PR DESCRIPTION
## Issue

When trying to use this library in Alertmanager, I got the following error:

```
  File "/var/lib/juju/agents/unit-am-0/charm/lib/charms/observability_libs/v1/cert_handler.py", line 214, in _on_config_changed
    self._generate_csr(renew=True)
  File "/var/lib/juju/agents/unit-am-0/charm/lib/charms/observability_libs/v1/cert_handler.py", line 233, in _generate_csr
    raise RuntimeError(
RuntimeError: private key unset. call _generate_privkey() before you call this method.
```

In fact, `_on_config_changed()` doesn't call `_generate_privkey()`.

The issue is that a race condition probably causes **config-changed** to arrive before **certificates-relation-joined**, which doesn't generate the private key beforehand.

Please note that calling the function multiple times isn't a problem as the function will just skip :)


## Solution

Add a call to `_generate_privkey()` in the `_on_config_changed()` handler.