### PR TITLE
Use tls-certificates v3

### DIFF
--- a/lib/charms/observability_libs/v0/cert_handler.py
+++ b/lib/charms/observability_libs/v0/cert_handler.py
@@ -45,7 +45,7 @@ try:
         CertificateAvailableEvent,
         CertificateExpiringEvent,
         CertificateInvalidatedEvent,
-        TLSCertificatesRequiresV2,
+        TLSCertificatesRequiresV3,
         generate_csr,
         generate_private_key,
     )
@@ -132,7 +132,7 @@ class CertHandler(Object):
         self.peer_relation_name = peer_relation_name
         self.certificates_relation_name = certificates_relation_name
 
-        self.certificates = TLSCertificatesRequiresV2(self.charm, self.certificates_relation_name)
+        self.certificates = TLSCertificatesRequiresV3(self.charm, self.certificates_relation_name)
 
         self.framework.observe(
             self.charm.on.config_changed,

--- a/lib/charms/observability_libs/v0/cert_handler.py
+++ b/lib/charms/observability_libs/v0/cert_handler.py
@@ -382,7 +382,7 @@ class CertHandler(Object):
         return ""
 
     @_chain.setter
-    def _chain(self, value: List[str]):
+    def _chain(self, value: str):
         # Caller must guard. We want the setter to fail loudly. Failure must have a side effect.
         rel = self._peer_relation
         assert rel is not None  # For type checker

--- a/lib/charms/observability_libs/v0/cert_handler.py
+++ b/lib/charms/observability_libs/v0/cert_handler.py
@@ -40,7 +40,7 @@ from itertools import filterfalse
 from typing import List, Optional, Union, cast
 
 try:
-    from charms.tls_certificates_interface.v2.tls_certificates import (  # type: ignore
+    from charms.tls_certificates_interface.v3.tls_certificates import (  # type: ignore
         AllCertificatesInvalidatedEvent,
         CertificateAvailableEvent,
         CertificateExpiringEvent,
@@ -51,7 +51,7 @@ try:
     )
 except ImportError as e:
     raise ImportError(
-        "failed to import charms.tls_certificates_interface.v2.tls_certificates; "
+        "failed to import charms.tls_certificates_interface.v3.tls_certificates; "
         "Either the library itself is missing (please get it through charmcraft fetch-lib) "
         "or one of its dependencies is unmet."
     ) from e
@@ -67,7 +67,7 @@ logger = logging.getLogger(__name__)
 
 LIBID = "b5cd5cd580f3428fa5f59a8876dcbe6a"
 LIBAPI = 0
-LIBPATCH = 9
+LIBPATCH = 10
 
 
 def is_ip_address(value: str) -> bool:

--- a/lib/charms/observability_libs/v0/cert_handler.py
+++ b/lib/charms/observability_libs/v0/cert_handler.py
@@ -282,7 +282,7 @@ class CertHandler(Object):
         if clear_cert:
             self._ca_cert = ""
             self._server_cert = ""
-            self._chain = []
+            self._chain = ""
 
     def _on_certificate_available(self, event: CertificateAvailableEvent) -> None:
         """Get the certificate from the event and store it in a peer relation.
@@ -304,7 +304,7 @@ class CertHandler(Object):
         if event_csr == self._csr:
             self._ca_cert = event.ca
             self._server_cert = event.certificate
-            self._chain = event.chain
+            self._chain = event.chain_as_pem()
             self.on.cert_changed.emit()  # pyright: ignore
 
     @property
@@ -375,11 +375,11 @@ class CertHandler(Object):
         rel.data[self.charm.unit].update({"certificate": value})
 
     @property
-    def _chain(self) -> List[str]:
+    def _chain(self) -> str:
         if self._peer_relation:
-            if chain := self._peer_relation.data[self.charm.unit].get("chain", []):
+            if chain := self._peer_relation.data[self.charm.unit].get("chain", ""):
                 return json.loads(cast(str, chain))
-        return []
+        return ""
 
     @_chain.setter
     def _chain(self, value: List[str]):
@@ -389,7 +389,7 @@ class CertHandler(Object):
         rel.data[self.charm.unit].update({"chain": json.dumps(value)})
 
     @property
-    def chain(self) -> List[str]:
+    def chain(self) -> str:
         """Return the ca chain."""
         return self._chain
 


### PR DESCRIPTION
## Issue
Certificates generated by the charm don't include intermediates: https://github.com/canonical/httprequest-lego-k8s-operator/issues/93.


## Solution
This was addressed by https://github.com/canonical/tls-certificates-interface/pull/141 in v3, but wasn't back-ported to v2, so bump to v3.

Technically the diff presents a breaking change for the `.chain` property, but we haven't really used it anywhere yet.

In tandem with:
- https://github.com/canonical/traefik-k8s-operator/pull/317

## Upgrade notes
Due to this diff:
```diff
-if chain := self._peer_relation.data[self.charm.unit].get("chain", []):
+if chain := self._peer_relation.data[self.charm.unit].get("chain", ""):
```
on charm upgrade, the new charm would be expecting a `str`, but peer data would hold a `List[str]`. For this reason, first unrelate (tls_certificates), upgrade, and then relate again.