### PR TITLE
Revert cert_handler to use tls-certs v2

### DIFF
--- a/lib/charms/observability_libs/v0/cert_handler.py
+++ b/lib/charms/observability_libs/v0/cert_handler.py
@@ -385,7 +385,7 @@ class CertHandler(Object):
     def _chain(self) -> List[str]:
         if self._peer_relation:
             if chain := self._peer_relation.data[self.charm.unit].get("chain", []):
-                return json.loads(chain)
+                return cast(list, json.loads(cast(str, chain)))
         return []
 
     @_chain.setter

--- a/lib/charms/observability_libs/v0/cert_handler.py
+++ b/lib/charms/observability_libs/v0/cert_handler.py
@@ -40,18 +40,18 @@ from itertools import filterfalse
 from typing import List, Optional, Union, cast
 
 try:
-    from charms.tls_certificates_interface.v3.tls_certificates import (  # type: ignore
+    from charms.tls_certificates_interface.v2.tls_certificates import (  # type: ignore
         AllCertificatesInvalidatedEvent,
         CertificateAvailableEvent,
         CertificateExpiringEvent,
         CertificateInvalidatedEvent,
-        TLSCertificatesRequiresV3,
+        TLSCertificatesRequiresV2,
         generate_csr,
         generate_private_key,
     )
 except ImportError as e:
     raise ImportError(
-        "failed to import charms.tls_certificates_interface.v3.tls_certificates; "
+        "failed to import charms.tls_certificates_interface.v2.tls_certificates; "
         "Either the library itself is missing (please get it through charmcraft fetch-lib) "
         "or one of its dependencies is unmet."
     ) from e
@@ -67,7 +67,7 @@ logger = logging.getLogger(__name__)
 
 LIBID = "b5cd5cd580f3428fa5f59a8876dcbe6a"
 LIBAPI = 0
-LIBPATCH = 12
+LIBPATCH = 13
 
 
 def is_ip_address(value: str) -> bool:
@@ -132,7 +132,7 @@ class CertHandler(Object):
         self.peer_relation_name = peer_relation_name
         self.certificates_relation_name = certificates_relation_name
 
-        self.certificates = TLSCertificatesRequiresV3(self.charm, self.certificates_relation_name)
+        self.certificates = TLSCertificatesRequiresV2(self.charm, self.certificates_relation_name)
 
         self.framework.observe(
             self.charm.on.config_changed,
@@ -289,7 +289,7 @@ class CertHandler(Object):
         if clear_cert:
             self._ca_cert = ""
             self._server_cert = ""
-            self._chain = ""
+            self._chain = []
 
     def _on_certificate_available(self, event: CertificateAvailableEvent) -> None:
         """Get the certificate from the event and store it in a peer relation.
@@ -311,7 +311,7 @@ class CertHandler(Object):
         if event_csr == self._csr:
             self._ca_cert = event.ca
             self._server_cert = event.certificate
-            self._chain = event.chain_as_pem()
+            self._chain = event.chain
             self.on.cert_changed.emit()  # pyright: ignore
 
     @property
@@ -382,29 +382,21 @@ class CertHandler(Object):
         rel.data[self.charm.unit].update({"certificate": value})
 
     @property
-    def _chain(self) -> str:
+    def _chain(self) -> List[str]:
         if self._peer_relation:
-            if chain := self._peer_relation.data[self.charm.unit].get("chain", ""):
-                chain = json.loads(chain)
-
-                # In a previous version of this lib, chain used to be a list.
-                # Convert the List[str] to str, per
-                # https://github.com/canonical/tls-certificates-interface/pull/141
-                if isinstance(chain, list):
-                    chain = "\n\n".join(reversed(chain))
-
-                return cast(str, chain)
-        return ""
+            if chain := self._peer_relation.data[self.charm.unit].get("chain", []):
+                return json.loads(chain)
+        return []
 
     @_chain.setter
-    def _chain(self, value: str):
+    def _chain(self, value: List[str]):
         # Caller must guard. We want the setter to fail loudly. Failure must have a side effect.
         rel = self._peer_relation
         assert rel is not None  # For type checker
         rel.data[self.charm.unit].update({"chain": json.dumps(value)})
 
     @property
-    def chain(self) -> str:
+    def chain(self) -> List[str]:
         """Return the ca chain."""
         return self._chain
 


### PR DESCRIPTION
## Issue
Grafana agent must be deployable on juju 2.9 models, so cannot use secrets.


## Solution
Revert to tls-certs lib v2.

In tandem with:
- https://github.com/canonical/grafana-agent-operator/pull/106