### PR TITLE
add check for private key existence

### DIFF
--- a/lib/charms/observability_libs/v1/cert_handler.py
+++ b/lib/charms/observability_libs/v1/cert_handler.py
@@ -477,6 +477,14 @@ class CertHandler(Object):
         """Emit cert-changed."""
         self.on.cert_changed.emit()  # pyright: ignore
 
+    def private_key_exists(self) -> bool:
+        """check if private key is already generated
+
+        Returns:
+            bool: a boolean value indicating if a private key is generated
+        """
+        return False if self.vault.get_value("private-key") is None else True
+        
     @property
     def private_key(self) -> str:
         """Private key.


### PR DESCRIPTION
## Issue
by simply getting the `private_key` property, it now generates a new private key if it doesn't exist. Some charms access that property as a way of checking if its been generated or not (alertmanager), so it falsely generates a private key for the charm without even enabling tls on that charm.

## Solution
added a new function to check for the existence of the key


