### PR TITLE
Add `available` property to cert_handler

### DIFF
--- a/lib/charms/observability_libs/v1/cert_handler.py
+++ b/lib/charms/observability_libs/v1/cert_handler.py
@@ -391,29 +391,36 @@ class CertHandler(Object):
 
     @property
     def enabled(self) -> bool:
-        """Boolean indicating whether the charm has a tls_certificates relation."""
+        """Boolean indicating whether the charm has a tls_certificates relation.
+
+        See also the `available` property.
+        """
         # We need to check for units as a temporary workaround because of https://bugs.launchpad.net/juju/+bug/2024583
         # This could in theory not work correctly on scale down to 0 but it is necessary for the moment.
 
-        if not self.charm.model.get_relation(self.certificates_relation_name):
+        if not self.relation:
             return False
 
-        if not self.charm.model.get_relation(
-            self.certificates_relation_name
-        ).units:  # pyright: ignore
+        if not self.relation.units:  # pyright: ignore
             return False
 
-        if not self.charm.model.get_relation(
-            self.certificates_relation_name
-        ).app:  # pyright: ignore
+        if not self.relation.app:  # pyright: ignore
             return False
 
-        if not self.charm.model.get_relation(
-            self.certificates_relation_name
-        ).data:  # pyright: ignore
+        if not self.relation.data:  # pyright: ignore
             return False
 
         return True
+
+    @property
+    def available(self) -> bool:
+        """Return True if all certs are available in relation data; False otherwise."""
+        return (
+            self.enabled
+            and self.server_cert is not None
+            and self.private_key is not None
+            and self.ca_cert is not None
+        )
 
     def _on_certificates_relation_joined(self, _) -> None:
         # this will only generate a csr if we don't have one already


### PR DESCRIPTION
## Issue
TLS has different stages of "readiness", and charms sometimes misuse one for another.


## Solution
Add a helper method to ease differentiation.

Tandem PRs:
- https://github.com/canonical/loki-k8s-operator/pull/416
- https://github.com/canonical/observability/pull/181
