### PR TITLE
parametrize peer relation name for vault backend storage

### DIFF
--- a/lib/charms/observability_libs/v1/cert_handler.py
+++ b/lib/charms/observability_libs/v1/cert_handler.py
@@ -274,6 +274,7 @@ class CertHandler(Object):
         *,
         key: str,
         certificates_relation_name: str = "certificates",
+        peer_relation_name: str = "peers",
         cert_subject: Optional[str] = None,
         sans: Optional[List[str]] = None,
     ):
@@ -285,7 +286,11 @@ class CertHandler(Object):
             charm: The owning charm.
             key: A manually-crafted, static, unique identifier used by ops to identify events.
              It shouldn't change between one event to another.
-            certificates_relation_name: Must match metadata.yaml.
+            certificates_relation_name: Name of the certificates relation over which we obtain TLS certificates.
+                Must match metadata.yaml.
+            peer_relation_name: Name of a peer relation used to store our secrets.
+                Only used on older Juju versions where secrets are not supported.
+                Must match metadata.yaml.
             cert_subject: Custom subject. Name collisions are under the caller's responsibility.
             sans: DNS names. If none are given, use FQDN.
         """
@@ -309,7 +314,7 @@ class CertHandler(Object):
             # self.framework.observe(self.charm.on.secret_remove, self._rotate_csr)
 
         else:
-            vault_backend = _RelationVaultBackend(charm, relation_name="peers")
+            vault_backend = _RelationVaultBackend(charm, relation_name=peer_relation_name)
         self.vault = Vault(vault_backend)
 
         self.certificates_relation_name = certificates_relation_name
@@ -514,7 +519,7 @@ class CertHandler(Object):
         # ignoring all but the last one.
         if len(csrs) > 1:
             logger.warning(
-                "Multiple CSRs found in `certificates` relation. "
+                f"Multiple CSRs found in {self.certificates_relation_name!r} relation. "
                 "cert_handler is not ready to expect it."
             )
 

--- a/tests/scenario/test_cert_handler/test_cert_handler_v1.py
+++ b/tests/scenario/test_cert_handler/test_cert_handler_v1.py
@@ -4,7 +4,7 @@ from pathlib import Path
 
 import pytest
 from ops import CharmBase
-from scenario import Context, Relation, State
+from scenario import Context, PeerRelation, Relation, State
 
 from lib.charms.observability_libs.v1.cert_handler import (
     CertHandler,
@@ -40,6 +40,35 @@ def certificates():
 def test_cert_joins(ctx, certificates, leader):
     with ctx.manager(
         certificates.joined_event, State(leader=leader, relations=[certificates], secrets=[])
+    ) as mgr:
+        mgr.run()
+        assert mgr.charm.ch.private_key
+
+
+class MyJuju2Charm(CharmBase):
+    META = {
+        "name": "fabio",
+        "requires": {"certificates": {"interface": "certificates"}},
+        "peers": {"myfunkypeers": {"interface": "peerymcpeer"}},
+    }
+
+    def __init__(self, fw):
+        super().__init__(fw)
+        self.ch = CertHandler(
+            self, key="ch", sans=[socket.getfqdn()], peer_relation_name="myfunkypeers"
+        )
+
+
+@pytest.fixture
+def ctx_juju2():
+    return Context(MyJuju2Charm, MyJuju2Charm.META, juju_version="2.0")
+
+
+@pytest.mark.parametrize("leader", (True, False))
+def test_cert_joins_peer_vault_backend(ctx_juju2, certificates, leader):
+    with ctx_juju2.manager(
+        certificates.joined_event,
+        State(leader=leader, relations=[certificates, PeerRelation("myfunkypeers")], secrets=[]),
     ) as mgr:
         mgr.run()
         assert mgr.charm.ch.private_key


### PR DESCRIPTION
Fixes #93

Allows passing arbitrary peer relation names instead of hardcoded "peers"