### PR TITLE
[cert handler] don't fail on vault.clear() failures

### DIFF
--- a/lib/charms/observability_libs/v1/cert_handler.py
+++ b/lib/charms/observability_libs/v1/cert_handler.py
@@ -67,7 +67,7 @@ logger = logging.getLogger(__name__)
 
 LIBID = "b5cd5cd580f3428fa5f59a8876dcbe6a"
 LIBAPI = 1
-LIBPATCH = 10
+LIBPATCH = 11
 
 VAULT_SECRET_LABEL = "cert-handler-private-vault"
 

--- a/lib/charms/observability_libs/v1/cert_handler.py
+++ b/lib/charms/observability_libs/v1/cert_handler.py
@@ -260,7 +260,13 @@ class Vault:
 
     def clear(self):
         """Clear the vault."""
-        self._backend.clear()
+        try:
+            self._backend.clear()
+        except SecretNotFoundError:
+            # guard against: https://github.com/canonical/observability-libs/issues/95
+            # this is fine, it might mean an earlier hook had already called .clear()
+            # not sure what exactly the root cause is, might be a juju bug
+            logger.debug("Could not clear vault: secret is gone already.")
 
 
 class CertHandler(Object):


### PR DESCRIPTION
## Issue
Fixes #95

## Solution
don't raise when calling `Secret.remove_all_revisions` fails with SecretNotFound.

## Context
Unclear exactly what's causing this, as the _SecretVaultBackend already catches SecretNotFound and initializes a fresh secret in that case. It's odd that two lines later info-get on that fresh secret raises SecretNotFound again.
Discussion with juju is ongoing to see whether we can find out what's going on.

## Testing Instructions
Attempt to repro #95 and see if it's fixed
