### PR TITLE
Fix traefik lb being constantly re-created on controller restart

### DIFF
--- a/lib/charms/observability_libs/v1/kubernetes_service_patch.py
+++ b/lib/charms/observability_libs/v1/kubernetes_service_patch.py
@@ -228,6 +228,8 @@ class KubernetesServicePatch(Object):
         self.framework.observe(charm.on.install, self._patch)
         self.framework.observe(charm.on.upgrade_charm, self._on_upgrade_charm)
         self.framework.observe(charm.on.update_status, self._patch)
+        # Sometimes Juju doesn't clean-up a manually created LB service,
+        # so we clean it up ourselves just in case.
         self.framework.observe(charm.on.remove, self._remove_service)
 
         # apply user defined events
@@ -359,7 +361,7 @@ class KubernetesServicePatch(Object):
 
     def _on_upgrade_charm(self, event: UpgradeCharmEvent):
         """Handle the upgrade charm event."""
-        # Handling the case when a user changes the service type from LB to ClusterIP in an upgrade, previous LB should be deleted.
+        # If a charm author changed the service type from LB to ClusterIP across an upgrade, we need to delete the previous LB.
         if self.service_type == "ClusterIP":
 
             client = Client()  # pyright: ignore
@@ -376,15 +378,15 @@ class KubernetesServicePatch(Object):
                     or not service.spec
                     or not service.spec.type
                 ):
-                    logger.warning("Skipping resource with incomplete metadata.")
+                    logger.warning("Service patch: skipping resource with incomplete metadata: %s.", service)
                     continue
                 if service.spec.type == "LoadBalancer":
                     client.delete(Service, service.metadata.name, namespace=self._namespace)
                     logger.info(
-                        f"LoadBalancer service {service.metadata.name} deleted successfully."
+                        f"LoadBalancer service {service.metadata.name} deleted."
                     )
 
-        # CContinue the upgrade flow normally
+        # Continue the upgrade flow normally
         self._patch(event)
 
     def _remove_service(self, _):
@@ -403,12 +405,12 @@ class KubernetesServicePatch(Object):
 
         try:
             client.delete(Service, self.service_name, namespace=self._namespace)
-            logger.info(f"Service {self.service_name} deleted successfully.")
+            logger.info("The patched k8s service '%s' was deleted.", self.service_name)
         except ApiError as e:
             if e.status.code == 404:
                 # Service not found, so no action needed
                 return
-                # Re-raise for other statuses
+            # Re-raise for other statuses
             raise
 
     @property

--- a/lib/charms/observability_libs/v1/kubernetes_service_patch.py
+++ b/lib/charms/observability_libs/v1/kubernetes_service_patch.py
@@ -145,12 +145,12 @@ def setUp(self, *unused):
 
 import logging
 from types import MethodType
-from typing import List, Literal, Optional, Union
+from typing import Any, List, Literal, Optional, Union
 
 from lightkube import ApiError, Client  # pyright: ignore
 from lightkube.core import exceptions
 from lightkube.models.core_v1 import ServicePort, ServiceSpec
-from lightkube.models.meta_v1 import LabelSelector, ObjectMeta
+from lightkube.models.meta_v1 import ObjectMeta
 from lightkube.resources.core_v1 import Service
 from lightkube.types import PatchType
 from ops import UpgradeCharmEvent
@@ -365,10 +365,10 @@ class KubernetesServicePatch(Object):
             client = Client()  # pyright: ignore
 
             # Define a label selector to find services related to the app
-            selector = LabelSelector(matchLabels={"app.kubernetes.io/name": self._app})
+            selector: dict[str, Any] = {"app.kubernetes.io/name": self._app}
 
             # Check if any service of type LoadBalancer exists
-            services = client.list(Service, namespace=self._namespace, labels=selector.to_dict())
+            services = client.list(Service, namespace=self._namespace, labels=selector)
             for service in services:
                 if (
                     not service.metadata

--- a/lib/charms/observability_libs/v1/kubernetes_service_patch.py
+++ b/lib/charms/observability_libs/v1/kubernetes_service_patch.py
@@ -166,7 +166,7 @@ LIBAPI = 1
 
 # Increment this PATCH version before using `charmcraft publish-lib` or reset
 # to 0 if you are raising the major API version
-LIBPATCH = 11
+LIBPATCH = 12
 
 ServiceType = Literal["ClusterIP", "LoadBalancer"]
 
@@ -227,7 +227,7 @@ class KubernetesServicePatch(Object):
         self.framework.observe(charm.on.install, self._patch)
         self.framework.observe(charm.on.upgrade_charm, self._patch)
         self.framework.observe(charm.on.update_status, self._patch)
-        self.framework.observe(charm.on.stop, self._remove_service)
+        self.framework.observe(charm.on.remove, self._remove_service)
 
         # apply user defined events
         if refresh_event:
@@ -372,10 +372,11 @@ class KubernetesServicePatch(Object):
 
         try:
             client.delete(Service, self.service_name, namespace=self._namespace)
+            logger.info(f'Service {self.service_name} deleted successfully.')
         except ApiError as e:
             if e.status.code == 404:
                 # Service not found, so no action needed
-                pass
+                return
             else:
                 # Re-raise for other statuses
                 raise

--- a/lib/charms/observability_libs/v1/kubernetes_service_patch.py
+++ b/lib/charms/observability_libs/v1/kubernetes_service_patch.py
@@ -378,13 +378,13 @@ class KubernetesServicePatch(Object):
                     or not service.spec
                     or not service.spec.type
                 ):
-                    logger.warning("Service patch: skipping resource with incomplete metadata: %s.", service)
+                    logger.warning(
+                        "Service patch: skipping resource with incomplete metadata: %s.", service
+                    )
                     continue
                 if service.spec.type == "LoadBalancer":
                     client.delete(Service, service.metadata.name, namespace=self._namespace)
-                    logger.info(
-                        f"LoadBalancer service {service.metadata.name} deleted."
-                    )
+                    logger.info(f"LoadBalancer service {service.metadata.name} deleted.")
 
         # Continue the upgrade flow normally
         self._patch(event)

--- a/lib/charms/observability_libs/v1/kubernetes_service_patch.py
+++ b/lib/charms/observability_libs/v1/kubernetes_service_patch.py
@@ -153,6 +153,7 @@ from lightkube.models.core_v1 import ServicePort, ServiceSpec
 from lightkube.models.meta_v1 import ObjectMeta
 from lightkube.resources.core_v1 import Service
 from lightkube.types import PatchType
+from ops import UpgradeCharmEvent
 from ops.charm import CharmBase
 from ops.framework import BoundEvent, Object
 
@@ -225,7 +226,7 @@ class KubernetesServicePatch(Object):
         assert isinstance(self._patch, MethodType)
         # Ensure this patch is applied during the 'install' and 'upgrade-charm' events
         self.framework.observe(charm.on.install, self._patch)
-        self.framework.observe(charm.on.upgrade_charm, self._patch)
+        self.framework.observe(charm.on.upgrade_charm, self._on_upgrade_charm)
         self.framework.observe(charm.on.update_status, self._patch)
         self.framework.observe(charm.on.remove, self._remove_service)
 
@@ -356,6 +357,31 @@ class KubernetesServicePatch(Object):
         ]  # noqa: E501
         return expected_ports == fetched_ports
 
+    def _on_upgrade_charm(self, event: UpgradeCharmEvent):
+        """Handle the upgrade charm event."""
+        # Handling the case when a user changes the service type from LB to ClusterIP in an upgrade, previous LB should be deleted.
+        if self.service_type == "ClusterIP":
+
+            client = Client()  # pyright: ignore
+
+            # Define a label selector to find services related to the app
+            selector = {"app.kubernetes.io/name": self._app}
+
+            # Check if any service of type LoadBalancer exists
+            services = client.list(Service, namespace=self._namespace, labels=selector)
+            for service in services:
+                if not service.metadata or not service.metadata.name:
+                    logger.warning("Skipping resource with incomplete metadata.")
+                    continue
+                if service.spec.type == "LoadBalancer":
+                    client.delete(Service, service.metadata.name, namespace=self._namespace)
+                    logger.info(
+                        f"LoadBalancer service {service.metadata.name} deleted successfully."
+                    )
+
+        # CContinue the upgrade flow normally
+        self._patch(event)
+
     def _remove_service(self, _):
         """Remove a Kubernetes service associated with this charm.
 
@@ -372,14 +398,13 @@ class KubernetesServicePatch(Object):
 
         try:
             client.delete(Service, self.service_name, namespace=self._namespace)
-            logger.info(f'Service {self.service_name} deleted successfully.')
+            logger.info(f"Service {self.service_name} deleted successfully.")
         except ApiError as e:
             if e.status.code == 404:
                 # Service not found, so no action needed
                 return
-            else:
                 # Re-raise for other statuses
-                raise
+            raise
 
     @property
     def _app(self) -> str:

--- a/tests/unit/test_kubernetes_service.py
+++ b/tests/unit/test_kubernetes_service.py
@@ -375,8 +375,11 @@ class TestK8sServicePatch(unittest.TestCase):
             self.assertEqual(patch.call_count, 1)
 
     @patch(f"{CL_PATH}._namespace", "test")
-    def test_given_initialized_charm_when_upgrade_event_then_event_listener_is_attached(self):
+    @patch(f"{MOD_PATH}.Client")
+    def test_given_initialized_charm_when_upgrade_event_then_event_listener_is_attached(self,client):
         charm = self.harness.charm
+        client.return_value = client
+        client.list.return_value = []
         with mock.patch(f"{CL_PATH}._patch") as patch:
             charm.on.upgrade_charm.emit()
             self.assertEqual(patch.call_count, 1)

--- a/tests/unit/test_kubernetes_service.py
+++ b/tests/unit/test_kubernetes_service.py
@@ -374,6 +374,7 @@ class TestK8sServicePatch(unittest.TestCase):
             charm.on.install.emit()
             self.assertEqual(patch.call_count, 1)
 
+    @patch(f"{CL_PATH}._namespace", "test")
     def test_given_initialized_charm_when_upgrade_event_then_event_listener_is_attached(self):
         charm = self.harness.charm
         with mock.patch(f"{CL_PATH}._patch") as patch:

--- a/tests/unit/test_kubernetes_service.py
+++ b/tests/unit/test_kubernetes_service.py
@@ -376,7 +376,9 @@ class TestK8sServicePatch(unittest.TestCase):
 
     @patch(f"{CL_PATH}._namespace", "test")
     @patch(f"{MOD_PATH}.Client")
-    def test_given_initialized_charm_when_upgrade_event_then_event_listener_is_attached(self,client):
+    def test_given_initialized_charm_when_upgrade_event_then_event_listener_is_attached(
+        self, client
+    ):
         charm = self.harness.charm
         client.return_value = client
         client.list.return_value = []


### PR DESCRIPTION
## Issue
Traefik k8s service is recreated on each controller restart, this causes the k8s api to request a new external IP for the LB when a pool of IPs exist


## Solution
Call the `_remove_service` only when the `on_remove` hook is observed instead of calling it on each stop operation, also adjust the upgrade logic to delete any previous LB if service type is changed to `ClusterIP`


## Context
https://chat.canonical.com/canonical/pl/j7a74ztemt8pzgjjsgay59945r

## Testing Instructions

1. juju deploy traefik
2. juju deploy catalogue
3. juju relate traefik catalogue
4. kubectl delete pod controller-0 -n controller-k8s (wait until it's completely deleted and comes back up again)
5. kubectl get svc -A -o wide (observe that the traefik lb isn't restarted)

Tandem PR: https://github.com/canonical/traefik-k8s-operator/pull/381