### PR TITLE
Refresh CSR "whenever" needed

### DIFF
--- a/lib/charms/observability_libs/v1/cert_handler.py
+++ b/lib/charms/observability_libs/v1/cert_handler.py
@@ -386,10 +386,7 @@ class CertHandler(Object):
 
     def _refresh_csr_if_needed(self):
         """Refresh the latest current CSR with a new one if there are any SANs changes."""
-        if (
-            self._stored.csr_hash is not None
-            and self._stored.csr_hash != self._csr_hash
-        ):
+        if self._stored.csr_hash is not None and self._stored.csr_hash != self._csr_hash:
             self._generate_csr(renew=True)
 
     def _migrate_vault(self):
@@ -444,7 +441,7 @@ class CertHandler(Object):
         return True
 
     @property
-    def _csr_hash(self) -> int:
+    def _csr_hash(self) -> str:
         """A hash of the config that constructs the CSR.
 
         Only include here the config options that, should they change, should trigger a renewal of

--- a/lib/charms/observability_libs/v1/cert_handler.py
+++ b/lib/charms/observability_libs/v1/cert_handler.py
@@ -318,8 +318,8 @@ class CertHandler(Object):
 
         # Use fqdn only if no SANs were given, and drop empty/duplicate SANs
         sans = list(set(filter(None, (sans or [socket.getfqdn()]))))
-        self.sans_ip = sorted(list(filter(is_ip_address, sans)))
-        self.sans_dns = sorted(list(filterfalse(is_ip_address, sans)))
+        self.sans_ip = sorted(filter(is_ip_address, sans))
+        self.sans_dns = sorted(filterfalse(is_ip_address, sans))
 
         if self._check_juju_supports_secrets():
             vault_backend = _SecretVaultBackend(charm, secret_label=VAULT_SECRET_LABEL)

--- a/lib/charms/observability_libs/v1/cert_handler.py
+++ b/lib/charms/observability_libs/v1/cert_handler.py
@@ -318,8 +318,8 @@ class CertHandler(Object):
 
         # Use fqdn only if no SANs were given, and drop empty/duplicate SANs
         sans = list(set(filter(None, (sans or [socket.getfqdn()]))))
-        self.sans_ip = list(filter(is_ip_address, sans))
-        self.sans_dns = list(filterfalse(is_ip_address, sans))
+        self.sans_ip = sorted(list(filter(is_ip_address, sans)))
+        self.sans_dns = sorted(list(filterfalse(is_ip_address, sans)))
 
         if self._check_juju_supports_secrets():
             vault_backend = _SecretVaultBackend(charm, secret_label=VAULT_SECRET_LABEL)

--- a/tests/scenario/test_cert_handler/test_cert_handler_v1.py
+++ b/tests/scenario/test_cert_handler/test_cert_handler_v1.py
@@ -191,11 +191,14 @@ def test_cert_joins_peer_vault_backend(ctx_juju2, certificates, leader):
         assert mgr.charm.ch.private_key
 
 
+# CertHandler generates a cert on `config_changed` event
 @pytest.mark.parametrize(
-    "event,generate_call_count",
+    "event,expected_generate_calls",
     (("update_status", 0), ("start", 0), ("install", 0), ("config_changed", 1)),
 )
-def test_no_renew_if_no_initial_csr_was_generated(event, generate_call_count, ctx, certificates):
+def test_no_renew_if_no_initial_csr_was_generated(
+    event, expected_generate_calls, ctx, certificates
+):
     with _cert_renew_patch() as renew_patch:
         with _cert_generate_patch() as generate_patch:
             with ctx.manager(
@@ -205,7 +208,7 @@ def test_no_renew_if_no_initial_csr_was_generated(event, generate_call_count, ct
 
                 mgr.run()
                 assert renew_patch.call_count == 0
-                assert generate_patch.call_count == generate_call_count
+                assert generate_patch.call_count == expected_generate_calls
 
 
 @patch.object(CertHandler, "_stored", MagicMock())

--- a/tests/scenario/test_cert_handler/test_cert_handler_v1.py
+++ b/tests/scenario/test_cert_handler/test_cert_handler_v1.py
@@ -4,7 +4,7 @@ import socket
 import sys
 from contextlib import contextmanager
 from pathlib import Path
-from unittest.mock import patch
+from unittest.mock import MagicMock, patch
 
 import pytest
 from cryptography import x509
@@ -36,7 +36,7 @@ class MyCharm(CharmBase):
         if hostname := self._mock_san:
             sans.append(hostname)
 
-        self.ch = CertHandler(self, key="ch", sans=sans, refresh_events=[self.on.config_changed])
+        self.ch = CertHandler(self, key="ch", sans=sans)
 
     @property
     def _mock_san(self):
@@ -145,6 +145,14 @@ def _cert_renew_patch():
         yield patcher
 
 
+@contextmanager
+def _cert_generate_patch():
+    with patch(
+        "charms.tls_certificates_interface.v3.tls_certificates.TLSCertificatesRequiresV3.request_certificate_creation"
+    ) as patcher:
+        yield patcher
+
+
 @pytest.mark.parametrize("leader", (True, False))
 def test_cert_joins(ctx, certificates, leader):
     with ctx.manager(
@@ -183,46 +191,51 @@ def test_cert_joins_peer_vault_backend(ctx_juju2, certificates, leader):
         assert mgr.charm.ch.private_key
 
 
-def test_renew_csr_on_sans_change(ctx, certificates):
-    # generate a CSR
+@pytest.mark.parametrize(
+    "event,generate_call_count",
+    (("update_status", 0), ("start", 0), ("install", 0), ("config_changed", 1)),
+)
+def test_no_renew_if_no_initial_csr_was_generated(event, generate_call_count, ctx, certificates):
+    with _cert_renew_patch() as renew_patch:
+        with _cert_generate_patch() as generate_patch:
+            with ctx.manager(
+                event,
+                State(leader=True, relations=[certificates]),
+            ) as mgr:
+
+                mgr.run()
+                assert renew_patch.call_count == 0
+                assert generate_patch.call_count == generate_call_count
+
+
+@patch.object(CertHandler, "_stored", MagicMock())
+@pytest.mark.parametrize(
+    "is_relation, event",
+    (
+        (False, "start"),
+        (True, "changed_event"),
+        (False, "config_changed"),
+    ),
+)
+def test_csr_renew_on_any_event(is_relation, event, ctx, certificates):
     with ctx.manager(
-        certificates.joined_event,
-        State(leader=True, relations=[certificates]),
+        getattr(certificates, event) if is_relation else event,
+        State(
+            leader=True,
+            relations=[certificates],
+        ),
     ) as mgr:
         charm = mgr.charm
         state_out = mgr.run()
         orig_csr = get_csr_obj(charm.ch._csr)
         assert get_sans_from_csr(orig_csr) == {socket.getfqdn()}
 
-    # trigger a config_changed with a modified SAN
     with _sans_patch():
-        with ctx.manager("config_changed", state_out) as mgr:
+        with ctx.manager("update_status", state_out) as mgr:
             charm = mgr.charm
             state_out = mgr.run()
             csr = get_csr_obj(charm.ch._csr)
-            # assert CSR contains updated SAN
             assert get_sans_from_csr(csr) == {socket.getfqdn(), MOCK_HOSTNAME}
-
-
-def test_csr_no_change_on_wrong_refresh_event(ctx, certificates):
-    with _cert_renew_patch() as renew_patch:
-        with ctx.manager(
-            "config_changed",
-            State(leader=True, relations=[certificates]),
-        ) as mgr:
-            charm = mgr.charm
-            state_out = mgr.run()
-            orig_csr = get_csr_obj(charm.ch._csr)
-            assert get_sans_from_csr(orig_csr) == {socket.getfqdn()}
-
-    with _sans_patch():
-        with _cert_renew_patch() as renew_patch:
-            with ctx.manager("update_status", state_out) as mgr:
-                charm = mgr.charm
-                state_out = mgr.run()
-                csr = get_csr_obj(charm.ch._csr)
-                assert get_sans_from_csr(csr) == {socket.getfqdn()}
-                assert renew_patch.call_count == 0
 
 
 def test_csr_no_change(ctx, certificates):


### PR DESCRIPTION
## Issue
Currently, if SANs changed, we'd refresh the CSR only on the events passed to `refresh_events`. We should be doing that regardless of which event we're processing (as long as there was an initial CSR generated) since we might not know which specific events would trigger a SANs change.

## Solution
Add a "reconcile" logic in CertHandler constructor to refresh CSR if there has been any change to SANs.


## Testing Instructions
run `tox -e scenario-manual`

## Upgrade Notes
- Deprecation notice have been put if `refresh_events` is passed to CertHandler.
