### PR TITLE
Validate LB annotations before reconciling 

### DIFF
--- a/lib/charms/observability_libs/v1/kubernetes_service_patch.py
+++ b/lib/charms/observability_libs/v1/kubernetes_service_patch.py
@@ -145,7 +145,7 @@ def setUp(self, *unused):
 
 import logging
 from types import MethodType
-from typing import Any, List, Literal, Optional, Union
+from typing import Any, Dict, List, Literal, Optional, Union
 
 from lightkube import ApiError, Client  # pyright: ignore
 from lightkube.core import exceptions
@@ -305,11 +305,10 @@ class KubernetesServicePatch(Object):
         try:
             if self._is_patched(client):
                 return
-            if self.service_name != self._app:
-                if not self.service_type == "LoadBalancer":
-                    self._delete_and_create_service(client)
-                else:
-                    self._create_lb_service(client)
+            if self.service_type == "LoadBalancer":
+                self._create_lb_service(client)
+            else:
+                self._delete_and_create_service(client)
             client.patch(
                 Service,
                 self.service_name,
@@ -326,6 +325,10 @@ class KubernetesServicePatch(Object):
             logger.info("Kubernetes service '%s' patched successfully", self._app)
 
     def _delete_and_create_service(self, client: Client):
+
+        lb_selector = {"app.kubernetes.io/name": self._app}
+        self._delete_loadbalancer_services(client, lb_selector)
+
         service = client.get(Service, self._app, namespace=self._namespace)
         service.metadata.name = self.service_name  # type: ignore[attr-defined]
         service.metadata.resourceVersion = service.metadata.uid = None  # type: ignore[attr-defined]   # noqa: E501
@@ -384,31 +387,31 @@ class KubernetesServicePatch(Object):
         """Handle the upgrade charm event."""
         # If a charm author changed the service type from LB to ClusterIP across an upgrade, we need to delete the previous LB.
         if self.service_type == "ClusterIP":
-
             client = Client()  # pyright: ignore
-
-            # Define a label selector to find services related to the app
-            selector: dict[str, Any] = {"app.kubernetes.io/name": self._app}
-
-            # Check if any service of type LoadBalancer exists
-            services = client.list(Service, namespace=self._namespace, labels=selector)
-            for service in services:
-                if (
-                    not service.metadata
-                    or not service.metadata.name
-                    or not service.spec
-                    or not service.spec.type
-                ):
-                    logger.warning(
-                        "Service patch: skipping resource with incomplete metadata: %s.", service
-                    )
-                    continue
-                if service.spec.type == "LoadBalancer":
-                    client.delete(Service, service.metadata.name, namespace=self._namespace)
-                    logger.info(f"LoadBalancer service {service.metadata.name} deleted.")
+            lb_selector = {"app.kubernetes.io/name": self._app}
+            self._delete_loadbalancer_services(client, lb_selector)
 
         # Continue the upgrade flow normally
         self._patch(event)
+
+    def _delete_loadbalancer_services(self, client: Client, selector: Dict[str, Any]):
+        """List and delete LoadBalancer services associated with the charm."""
+        # Check if any service of type LoadBalancer exists
+        services = client.list(Service, namespace=self._namespace, labels=selector)
+        for service in services:
+            if (
+                not service.metadata
+                or not service.metadata.name
+                or not service.spec
+                or not service.spec.type
+            ):
+                logger.warning(
+                    "Service patch: skipping resource with incomplete metadata: %s.", service
+                )
+                continue
+            if service.spec.type == "LoadBalancer":
+                client.delete(Service, service.metadata.name, namespace=self._namespace)
+                logger.info(f"LoadBalancer service {service.metadata.name} deleted.")
 
     def _remove_service(self, _):
         """Remove a Kubernetes service associated with this charm.

--- a/lib/charms/observability_libs/v1/kubernetes_service_patch.py
+++ b/lib/charms/observability_libs/v1/kubernetes_service_patch.py
@@ -367,8 +367,12 @@ class KubernetesServicePatch(Object):
         ports_match = expected_ports == fetched_ports
 
         # Construct expected and fetched annotations
-        expected_annotations = self.service.metadata.annotations or {} # pyright: ignore[reportOptionalMemberAccess]
-        fetched_annotations = service.metadata.annotations or {} # pyright: ignore[reportOptionalMemberAccess]
+        expected_annotations = (
+            self.service.metadata.annotations or {}  # pyright: ignore[reportOptionalMemberAccess]
+        )
+        fetched_annotations = (
+            service.metadata.annotations or {}  # pyright: ignore[reportOptionalMemberAccess]
+        )
 
         # Validate annotations
         annotations_match = expected_annotations == fetched_annotations

--- a/tests/unit/test_kubernetes_service.py
+++ b/tests/unit/test_kubernetes_service.py
@@ -397,14 +397,22 @@ class TestK8sServicePatch(unittest.TestCase):
         # Patch should work even on a non-leader unit
         # Check we call the patch method on the client with the correct arguments
         client_patch.assert_called_with(
-            Service, "test-charm", charm.service_patch.service, patch_type=PatchType.MERGE
+            Service,
+            "test-charm",
+            charm.service_patch.service,
+            patch_type=PatchType.APPLY,
+            field_manager=charm.app.name,
         )
 
         self.harness.set_leader(True)
         charm.on.install.emit()
         # Check we call the patch method on the client with the correct arguments
         client_patch.assert_called_with(
-            Service, "test-charm", charm.service_patch.service, patch_type=PatchType.MERGE
+            Service,
+            "test-charm",
+            charm.service_patch.service,
+            patch_type=PatchType.APPLY,
+            field_manager=charm.app.name,
         )
 
         client_patch.side_effect = _FakeApiError(403)

--- a/tests/unit/test_kubernetes_service.py
+++ b/tests/unit/test_kubernetes_service.py
@@ -389,6 +389,7 @@ class TestK8sServicePatch(unittest.TestCase):
     @patch(f"{MOD_PATH}.Client.patch")
     @patch(f"{MOD_PATH}.ApiError", _FakeApiError)
     @patch(f"{CL_PATH}._is_patched", lambda *args: False)
+    @patch(f"{CL_PATH}._delete_and_create_service", lambda *args: None)
     @patch("lightkube.core.client.GenericSyncClient", Mock)
     def test_patch_k8s_service(self, client_patch):
         charm = self.harness.charm

--- a/tox.ini
+++ b/tox.ini
@@ -87,11 +87,12 @@ commands =
 [testenv:integration]
 description = Run integration tests
 deps =
-    juju ~= 3.1.0
+    juju
     lightkube
     lightkube-models
     pytest
     pytest-operator
+    -r{toxinidir}/requirements.txt
 commands =
     pytest -v --tb native --log-cli-level=INFO -s {posargs} {toxinidir}/tests/integration
 


### PR DESCRIPTION
## Issue
1 - Lib doesn't validate if annotations are changed to re-patch the service and only updates if ports are changed
2 - Lib currently uses `PatchType.MERGE` to update Kubernetes services, which doesn't handle removing old annotations when they are deleted.

## Solution
1 - Validate  `expected and fetched annotations` as part of `_is_patched` method.
2 - Use `PatchType.APPLY` to reconcile the annotations


## Context
Change is part of https://github.com/canonical/traefik-k8s-operator/issues/423 and is required to support adding custom annotations to load balancers.


## Testing Instructions
1 - Juju deploy traefik-k8s
2 - juju config traefik-k8s loadbalancer_annotations="key1=value1"
3 - kubectl describe traefik lb service and validate annotations

Tandem PR: https://github.com/canonical/traefik-k8s-operator/pull/428
