### PR TITLE
Workaround: observe relation changed directly

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -88,6 +88,8 @@ commands =
 description = Run integration tests
 deps =
     juju ~= 3.1.0
+    # https://github.com/juju/python-libjuju/issues/1184
+    websockets<14
     lightkube
     lightkube-models
     pytest


### PR DESCRIPTION
## Issue
Alertmanager integration test `test_tls_web` is consistently [failing](https://github.com/canonical/alertmanager-k8s-operator/actions/runs/12091332846/job/33719623135?pr=302#step:7:831) because the tls relation is considered not ready even after the tls relation is settled.

Looking at debug logs for the `test_tls_web` test,
```
unit-am-0: 23:08:44.449 DEBUG unit.am/0.juju-log certificates:1: Emitting Juju event certificates_relation_changed.
unit-am-0: 23:08:44.493 DEBUG unit.am/0.juju-log certificates:1: Emitting custom event <CertificateAvailableEvent via AlertmanagerCharm/TLSCertificatesRequiresV3[certificates]/on/cert
ificate_available[17]>.
unit-am-0: 23:08:44.500 DEBUG unit.am/0.juju-log certificates:1: Emitting custom event <CertChanged via AlertmanagerCharm/CertHandler[am-server-cert]/on/cert_changed[18]>.
unit-am-0: 23:08:47.877 INFO unit.am/0.juju-log certificates:1: Before update_layer. Certs on disk: True, tls ready: False. Plan: {'services': {'alertmanager': {'summary': 'alertmanager service', 'startup': 'enabled', 'override': 'replace', 'command': 'alertmanager --config.file=/etc/alertmanager/alertmanager.yml --storage.path=/alertmanager --web.listen-address=:9093 --cluster.listen-address= --web.external-url=http://am-0.am-endpoints.test-tls-web-te2o.svc.cluster.local:9093 --web.route-prefix=/ ', 'environment': {'http_proxy': '', 'https_proxy': '', 'no_proxy': '127.0.0.1,localhost,::1'}}}}
unit-am-0: 23:08:47.924 INFO unit.am/0.juju-log certificates:1: After update_layer. Certs on disk: True, tls ready: False. Plan: {'services': {'alertmanager': {'summary': 'alertmanager service', 'startup': 'enabled', 'override': 'replace', 'command': 'alertmanager --config.file=/etc/alertmanager/alertmanager.yml --storage.path=/alertmanager --web.listen-address=:9093 --cluster.listen-address= --web.external-url=http://am-0.am-endpoints.test-tls-web-te2o.svc.cluster.local:9093 --web.route-prefix=/ ', 'environment': {'http_proxy': '', 'https_proxy': '', 'no_proxy': '127.0.0.1,localhost,::1'}}}}
unit-am-0: 23:08:47.965 DEBUG unit.am/0.juju-log certificates:1: Emitting custom event <CertChanged via AlertmanagerCharm/CertHandler[am-server-cert]/on/cert_changed[18]>.
unit-am-0: 23:08:47.976 DEBUG unit.am/0.juju-log certificates:1: Emitting custom event <CertChanged via AlertmanagerCharm/CertHandler[am-server-cert]/on/cert_changed[18]>.
unit-am-0: 23:08:49.336 DEBUG unit.am/0.juju-log certificates:1: Emitting Juju event certificates_relation_joined.
unit-am-0: 23:08:50.538 DEBUG unit.am/0.juju-log certificates:1: Emitting Juju event certificates_relation_changed.
```

it seems like:
1. The custom `CertChanged` event is not being emitted after the core event `Emitting Juju event certificates_relation_changed`.
2. After the tls relation is settled, we end up with `Certs on disk: True, tls ready: False`, which doesn't make sense.


## Solution
Have the cert_handler lib observe the tls certificates `relation_changed` directly as a workaround.


## Context
https://github.com/canonical/alertmanager-k8s-operator/pull/302


## Testing Instructions
In alertmanager, `tox -e integration -- tests/integration/test_tls_web.py --keep-models`

