### PR TITLE
Deprecate `kubernetes_service_patch` lib

### DIFF
--- a/lib/charms/observability_libs/v1/kubernetes_service_patch.py
+++ b/lib/charms/observability_libs/v1/kubernetes_service_patch.py
@@ -7,7 +7,7 @@
 The `kubernetes_service_patch` library is DEPRECATED for patching the Kubernetes service created
 by Juju during the deployment of a charm and `ops.Unit.set_ports` functionality should be used for that instead.
 
-This library is intended to only be used to enable developers to create/patch Kubernetes ``LoadBalancer`` services.
+This library is intended to only be used to enable developers to create/patch Kubernetes `LoadBalancer` services.
 
 When initialised, this library binds a handler to the parent charm's `install` and `upgrade_charm`
 events which applies the patch to the cluster. This should ensure that the service ports are

--- a/lib/charms/observability_libs/v1/kubernetes_service_patch.py
+++ b/lib/charms/observability_libs/v1/kubernetes_service_patch.py
@@ -4,10 +4,10 @@
 """# KubernetesServicePatch Library.
 
 [DEPRECATED!]
-The `kubernetes_service_patch` library is DEPRECATED for `ClusterIP` services (i.e  Kubernetes services created
-by Juju during the deployment of a charm) and `ops.Unit.set_ports` functionality should be used instead.
+The `kubernetes_service_patch` library is DEPRECATED for patching the Kubernetes service created
+by Juju during the deployment of a charm and `ops.Unit.set_ports` functionality should be used for that instead.
 
-This library is intended to only be used to enable developers to patch Kubernetes ``LoadBalancer`` services.
+This library is intended to only be used to enable developers to create/patch Kubernetes ``LoadBalancer`` services.
 
 When initialised, this library binds a handler to the parent charm's `install` and `upgrade_charm`
 events which applies the patch to the cluster. This should ensure that the service ports are
@@ -198,9 +198,9 @@ class KubernetesServicePatch(Object):
         self.service_type = service_type
         if service_type == "ClusterIP":
             logger.warning(
-                "The ``kubernetes_service_patch v1`` library is DEPRECATED for ``ClusterIP`` services"
-                "(i.e  Kubernetes services created by Juju during the deployment of a charm) and "
-                "``ops.Unit.set_ports`` functionality should be used instead. "
+                "The ``kubernetes_service_patch v1`` library is DEPRECATED for patching "
+                "the Kubernetes service created by Juju during the deployment of a charm and "
+                "``ops.Unit.set_ports`` functionality should be used for that instead. "
                 "The ``kubernetes_service_patch v1`` library is now only maintained for ``LoadBalancer`` services."
             )
 

--- a/lib/charms/observability_libs/v1/kubernetes_service_patch.py
+++ b/lib/charms/observability_libs/v1/kubernetes_service_patch.py
@@ -7,7 +7,7 @@
 The `kubernetes_service_patch` library is DEPRECATED for patching the Kubernetes service created
 by Juju during the deployment of a charm and `ops.Unit.set_ports` functionality should be used for that instead.
 
-This library is intended to only be used to enable developers to create/patch Kubernetes `LoadBalancer` services.
+This library is intended to only be used to enable developers to create/patch Kubernetes `LoadBalancer`/`NodePort` services.
 
 When initialised, this library binds a handler to the parent charm's `install` and `upgrade_charm`
 events which applies the patch to the cluster. This should ensure that the service ports are
@@ -156,7 +156,7 @@ ServiceType = Literal["ClusterIP", "LoadBalancer"]
 
 
 class KubernetesServicePatch(Object):
-    """A utility for patching a Kubernetes LoadBalancer service."""
+    """A utility for patching a Kubernetes /NodePort service."""
 
     def __init__(
         self,
@@ -201,7 +201,7 @@ class KubernetesServicePatch(Object):
                 "The ``kubernetes_service_patch v1`` library is DEPRECATED for patching "
                 "the Kubernetes service created by Juju during the deployment of a charm and "
                 "``ops.Unit.set_ports`` functionality should be used for that instead. "
-                "The ``kubernetes_service_patch v1`` library is now only maintained for ``LoadBalancer`` services."
+                "The ``kubernetes_service_patch v1`` library is now only maintained for ``LoadBalancer``/``NodePort`` services."
             )
 
         self.service = self._service_object(


### PR DESCRIPTION
## Issue
This library has been used to patch the Kubernetes service created by Juju during the deployment of a charm to open ports on the unit and such. This functionality is available in Ops, as part of [ops.Unit.set_ports](https://ops.readthedocs.io/en/latest/#ops.Unit.set_ports). ~~However, this library is still used by charms like `traefik-k8s` to provide loadbalancing capabilities by creating/patching k8s LB services.~~

## Solution
- Add a deprecation warning and that ops.Unit.set_ports should be used instead.
~~- Update docstring to mention the same as well as that the library is now only intended to be used for creating/patching LoadBalancer k8s services.~~


