### PR TITLE
feat: deprecate juju_topology v0

### DIFF
--- a/lib/charms/observability_libs/v0/juju_topology.py
+++ b/lib/charms/observability_libs/v0/juju_topology.py
@@ -67,6 +67,8 @@ topology = JujuTopology(
 ```
 
 """
+
+import warnings
 from collections import OrderedDict
 from typing import Dict, List, Optional
 from uuid import UUID
@@ -119,6 +121,13 @@ class JujuTopology:
             unit: a unit name as a string
             charm_name: name of charm as a string
         """
+        warnings.warn(
+            """
+            observability_libs.v0.juju_topology is deprecated. Please import the
+            library from `cosl` instead: https://github.com/canonical/cos-lib
+            """,
+            DeprecationWarning,
+        )
         if not self.is_valid_uuid(model_uuid):
             raise InvalidUUIDError(model_uuid)
 
@@ -215,7 +224,8 @@ class JujuTopology:
 
         if remapped_keys:
             ret = OrderedDict(
-                (remapped_keys.get(k), v) if remapped_keys.get(k) else (k, v) for k, v in ret.items()  # type: ignore
+                (remapped_keys.get(k), v) if remapped_keys.get(k) else (k, v)
+                for k, v in ret.items()  # type: ignore
             )
 
         return ret


### PR DESCRIPTION
## Issue
`juju_topology` v0 is an old library we don't touch anymore. The current `juju_topology` we use is in cos-lib: 
https://github.com/canonical/cos-lib/blob/6cd3769727419f50018994591a90c0024542389b/src/cosl/juju_topology.py


## Solution
Add a deprecation warning, as an intermediate step before removing the library entirely.
