### PR TITLE
feat: raise on patching charm container

### DIFF
--- a/lib/charms/observability_libs/v0/kubernetes_compute_resources_patch.py
+++ b/lib/charms/observability_libs/v0/kubernetes_compute_resources_patch.py
@@ -616,7 +616,7 @@ class KubernetesComputeResourcesPatch(Object):
     def _on_config_changed(self, _):
         self._patch()
 
-    def _patch(self) -> None:
+    def _patch(self) -> None: # noqa: C901
         """Patch the Kubernetes resources created by Juju to limit cpu or mem.
 
         This method will keep on retrying to patch the kubernetes resource for a default duration of 20 seconds

--- a/lib/charms/observability_libs/v0/kubernetes_compute_resources_patch.py
+++ b/lib/charms/observability_libs/v0/kubernetes_compute_resources_patch.py
@@ -569,7 +569,6 @@ class KubernetesComputeResourcesPatch(Object):
         *,
         resource_reqs_func: Callable[[], ResourceRequirements],
         refresh_event: Optional[Union[BoundEvent, List[BoundEvent]]] = None,
-        allow_patching_charm_container: bool = False
     ):
         """Constructor for KubernetesComputeResourcesPatch.
 
@@ -583,15 +582,14 @@ class KubernetesComputeResourcesPatch(Object):
               only raise ValueError.
             refresh_event: an optional bound event or list of bound events which
                 will be observed to re-apply the patch.
-            allow_patching_charm_container: Whether to allow patching the "charm" container.
         """
         super().__init__(charm, "{}_{}".format(self.__class__.__name__, container_name))
 
-        if container_name == "charm" and not allow_patching_charm_container:
+        if container_name == "charm":
             raise ValueError(
                 "Starting with juju 3.6.9, juju manages the charm container "
-                "constraints and you'll likely get errors by doing this if the charm is deployed "
-                "on higher juju versions. To suppress this warning pass `allow_patching_charm_container=True`."
+                "constraints and you'll get errors by doing this if the charm is deployed "
+                "on higher juju versions."
             )
 
         self._charm = charm

--- a/lib/charms/observability_libs/v0/kubernetes_compute_resources_patch.py
+++ b/lib/charms/observability_libs/v0/kubernetes_compute_resources_patch.py
@@ -667,7 +667,9 @@ class KubernetesComputeResourcesPatch(Object):
         except ApiError as e:
             if e.status.code == 403:
                 msg = f"Kubernetes resources patch failed: `juju trust` this application. {e}"
-
+            elif e.status.code == 409:
+                msg = (f"Kubernetes resources patch failed: someone else (likely juju) "
+                       f"owns the resources you're trying to patch {e}")
             else:
                 msg = f"Kubernetes resources patch failed: {e}"
 

--- a/lib/charms/observability_libs/v0/kubernetes_compute_resources_patch.py
+++ b/lib/charms/observability_libs/v0/kubernetes_compute_resources_patch.py
@@ -149,7 +149,7 @@ LIBAPI = 0
 
 # Increment this PATCH version before using `charmcraft publish-lib` or reset
 # to 0 if you are raising the major API version
-LIBPATCH = 8
+LIBPATCH = 9
 
 
 _Decimal = Union[Decimal, float, str, int]  # types that are potentially convertible to Decimal
@@ -569,6 +569,7 @@ class KubernetesComputeResourcesPatch(Object):
         *,
         resource_reqs_func: Callable[[], ResourceRequirements],
         refresh_event: Optional[Union[BoundEvent, List[BoundEvent]]] = None,
+        allow_patching_charm_container: bool = False
     ):
         """Constructor for KubernetesComputeResourcesPatch.
 
@@ -582,8 +583,17 @@ class KubernetesComputeResourcesPatch(Object):
               only raise ValueError.
             refresh_event: an optional bound event or list of bound events which
                 will be observed to re-apply the patch.
+            allow_patching_charm_container: Whether to allow patching the "charm" container.
         """
         super().__init__(charm, "{}_{}".format(self.__class__.__name__, container_name))
+
+        if container_name == "charm" and not allow_patching_charm_container:
+            raise ValueError(
+                "Starting with juju 3.6.9, juju manages the charm container "
+                "constraints and you'll likely get errors by doing this if the charm is deployed "
+                "on higher juju versions. To suppress this warning pass `allow_patching_charm_container=True`."
+            )
+
         self._charm = charm
         self._container_name = container_name
         self.resource_reqs_func = resource_reqs_func

--- a/lib/charms/observability_libs/v1/cert_handler.py
+++ b/lib/charms/observability_libs/v1/cert_handler.py
@@ -44,7 +44,7 @@ logger = logging.getLogger(__name__)
 
 LIBID = "b5cd5cd580f3428fa5f59a8876dcbe6a"
 LIBAPI = 1
-LIBPATCH = 18
+LIBPATCH = 19
 
 VAULT_SECRET_LABEL = "cert-handler-private-vault"
 
@@ -621,7 +621,7 @@ class CertHandler(Object):
         cert = self.get_cert()
         if not cert:
             return None
-        chain = cert.chain_as_pem_string()
+        chain = cert.chain_as_pem_string()  # type: ignore
         if cert.certificate not in chain:
             # add server cert to chain
             chain = cert.certificate + "\n\n" + chain

--- a/tests/unit/test_kubernetes_compute_resources.py
+++ b/tests/unit/test_kubernetes_compute_resources.py
@@ -181,12 +181,3 @@ def test_patch_charm_container_fails_with_warning(_):
             "charm",
             resource_reqs_func=lambda: adjust_resource_requirements(None, None),
         )
-
-    # Unless we pass an explicit override
-    KubernetesComputeResourcesPatch(
-            mm,
-            "charm",
-            resource_reqs_func=lambda: adjust_resource_requirements(None, None),
-            allow_patching_charm_container=True
-        )
-

--- a/tests/unit/test_kubernetes_compute_resources.py
+++ b/tests/unit/test_kubernetes_compute_resources.py
@@ -5,6 +5,7 @@ from unittest import mock
 from unittest.mock import MagicMock, Mock, patch
 
 import httpx
+import pytest
 import tenacity
 import yaml
 from charms.observability_libs.v0.kubernetes_compute_resources_patch import (
@@ -155,3 +156,23 @@ class TestResourceSpecDictValidation(unittest.TestCase):
 
         self.assertFalse(is_valid_spec({"bad": "combo"}))
         self.assertFalse(is_valid_spec({"invalid-key": "1"}))
+
+
+def test_patch_charm_container_fails_with_warning():
+    # When we try to patch the charm container we get an error
+    mm = MagicMock()
+    with pytest.raises(ValueError):
+        KubernetesComputeResourcesPatch(
+            mm,
+            "charm",
+            resource_reqs_func=lambda: adjust_resource_requirements(None, None),
+        )
+
+    # Unless we pass an explicit override
+    KubernetesComputeResourcesPatch(
+            mm,
+            "charm",
+            resource_reqs_func=lambda: adjust_resource_requirements(None, None),
+            allow_patching_charm_container=True
+        )
+

--- a/tests/unit/test_kubernetes_compute_resources.py
+++ b/tests/unit/test_kubernetes_compute_resources.py
@@ -158,7 +158,21 @@ class TestResourceSpecDictValidation(unittest.TestCase):
         self.assertFalse(is_valid_spec({"invalid-key": "1"}))
 
 
-def test_patch_charm_container_fails_with_warning():
+@mock.patch(
+    "charms.observability_libs.v0.kubernetes_compute_resources_patch.ResourcePatcher.apply",
+    MagicMock(return_value=None),
+)
+@mock.patch(
+    "charms.observability_libs.v0.kubernetes_compute_resources_patch.ResourcePatcher.is_failed",
+    MagicMock(return_value=(False, "")),
+)
+@mock.patch("lightkube.core.client.GenericSyncClient")
+@mock.patch.object(
+                KubernetesComputeResourcesPatch,
+                "_namespace",
+                "test-namespace",
+            )
+def test_patch_charm_container_fails_with_warning(_):
     # When we try to patch the charm container we get an error
     mm = MagicMock()
     with pytest.raises(ValueError):


### PR DESCRIPTION
Adds a warning to mitigate https://github.com/canonical/observability-libs/issues/128#issuecomment-3209698155
Whoever tries to use the KubernetesComputeResourcePatch on the `charm` container will now get an error unless they pass an explicit override.