### PR TITLE
fix readme link to charm libraries docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,5 +37,5 @@ charm following best practice guidelines, and `CONTRIBUTING.md` for developer gu
 [KubernetesServicePatch]: https://charmhub.io/observability-libs/libraries/kubernetes_service_patch
 [KubernetesComputeResourcesPatch]: https://charmhub.io/observability-libs/libraries/kubernetes_compute_resources_patch
 [bundle]: https://charmhub.io/cos-lite
-[charm libraries]: https://juju.is/docs/sdk/libraries
+[charm libraries]: https://documentation.ubuntu.com/charmlibs/explanation/charm-libs/
 [JujuTopology]: https://charmhub.io/observability-libs/libraries/juju_topology


### PR DESCRIPTION
## Issue
<!-- What issue is this PR trying to solve? -->
There is a very small issue in the README where the link for charm libraries points to a path in the [Juju docs](https://juju.is/docs/sdk/libraries) which doesn't exist anymore.

## Solution
<!-- A summary of the solution addressing the above issue -->
Changes the link to the charm libraries docs on [Charmhub](https://documentation.ubuntu.com/charmlibs/explanation/charm-libs/).

## Context
<!-- What is some specialized knowledge relevant to this project/technology -->


## Testing Instructions
<!-- What steps need to be taken to test this PR? -->


## Upgrade Notes
<!-- To upgrade from an older revision of charmed prometheus, ... -->
